### PR TITLE
fix(XeggeX, NonKYC): Don't resolve 429

### DIFF
--- a/trade/api/nonkyc_api.js
+++ b/trade/api/nonkyc_api.js
@@ -156,6 +156,7 @@ module.exports = function() {
 
     const nonkycError = data?.error;
     const nonkycErrorInfo = errorCodeDescriptions[nonkycError?.code];
+    const httpCodeInfo = errorCodeDescriptions[httpCode];
 
     const success = httpCode === 200 && !nonkycError;
 
@@ -173,14 +174,14 @@ module.exports = function() {
       if (success) {
         resolve(data);
       } else {
-        const nonkycErrorInfo = `[${error.code}] ${error.message || 'No error message'}`;
-        const errorMessage = httpCode ? `${httpCode} ${httpMessage}, ${nonkycErrorInfo}` : String(responseOrError);
+        const nonkycErrorInfoString = `[${error.code}] ${error.message || 'No error message'}`;
+        const errorMessage = httpCode ? `${httpCode} ${httpMessage}, ${nonkycErrorInfoString}` : String(responseOrError);
 
         if (typeof data === 'object') {
-          data.nonkycErrorInfo = nonkycErrorInfo;
+          data.nonkycErrorInfo = nonkycErrorInfoString;
         }
 
-        if (httpCode && !nonkycErrorInfo?.isTemporary) {
+        if (!httpCodeInfo?.isTemporary && !nonkycErrorInfo?.isTemporary) {
           log.log(`Nonkyc processed a request to ${url} with data ${reqParameters}, but with error: ${errorMessage}. Resolving…`);
 
           resolve(data);

--- a/trade/api/xeggex_api.js
+++ b/trade/api/xeggex_api.js
@@ -156,6 +156,7 @@ module.exports = function() {
 
     const xeggexError = data?.error;
     const xeggexErrorInfo = errorCodeDescriptions[xeggexError?.code];
+    const httpCodeInfo = errorCodeDescriptions[httpCode];
 
     const success = httpCode === 200 && !xeggexError;
 
@@ -173,14 +174,14 @@ module.exports = function() {
       if (success) {
         resolve(data);
       } else {
-        const xeggexErrorInfo = `[${error.code}] ${error.message || 'No error message'}`;
-        const errorMessage = httpCode ? `${httpCode} ${httpMessage}, ${xeggexErrorInfo}` : String(responseOrError);
+        const xeggexErrorInfoString = `[${error.code}] ${error.message || 'No error message'}`;
+        const errorMessage = httpCode ? `${httpCode} ${httpMessage}, ${xeggexErrorInfoString}` : String(responseOrError);
 
         if (typeof data === 'object') {
-          data.xeggexErrorInfo = xeggexErrorInfo;
+          data.xeggexErrorInfo = xeggexErrorInfoString;
         }
 
-        if (httpCode && !xeggexErrorInfo?.isTemporary) {
+        if (!httpCodeInfo?.isTemporary && !xeggexErrorInfo?.isTemporary) {
           log.log(`XeggeX processed a request to ${url} with data ${reqParameters}, but with error: ${errorMessage}. Resolving…`);
 
           resolve(data);


### PR DESCRIPTION
Fix for XeggeX and NonKYC exchanges.
Added a check that doesn't resolve temporary error codes, e.g., `429`.
