### PR TITLE
Fix FameEX markets API

### DIFF
--- a/trade/api/fameex_api.js
+++ b/trade/api/fameex_api.js
@@ -141,7 +141,7 @@ module.exports = function() {
         }
 
         if (httpCode === statusCodes.ok && !fameEXError?.isTemporary && data.data?.timestamp !== 0) {
-          log.log(`FameEX processed a request to ${url} with data ${reqParameters}, but with error: [${error.code}] ${error.msg}. Resolving…`);
+          log.log(`FameEX processed a request to ${url} with data ${reqParameters}, but with error: ${errorMessage}. Resolving…`);
           resolve(data);
         } else {
           log.warn(`Request to ${url} with data ${reqParameters} failed. details: ${errorMessage}. Rejecting…`);
@@ -222,6 +222,9 @@ module.exports = function() {
         params,
         method: type,
         timeout: 10000,
+        headers: {
+          'Accept-Encoding': 'application/gzip',
+        },
       };
 
       axios(httpOptions)


### PR DESCRIPTION
Issue:
The endpoint to get market list doesn't work https://fameex-docs.github.io/docs/api/spot/en/#get-all-trading-currency-pairs — https://api.fameex.com/v1/common/symbols

Workaround:
Add header `Accept-Encoding:application/gzip`.
