### PR TITLE
Docs: add AI agent documentation for the OSS branch

### DIFF
--- a/.github/ai-agent-instructions.md
+++ b/.github/ai-agent-instructions.md
@@ -4,6 +4,90 @@
 
 **Language policy**: Developers may talk to the agent in any language, but code, comments, docs, and commit messages must stay in English.
 
+## Organization-Wide Rules
+
+These repository-specific instructions extend the broader ADAMANT organization conventions rather than replace them.
+
+### English-only repository artifacts
+
+- Developers may communicate with AI in any language
+- All repository artifacts must be in English only
+- Write code, comments, docs, issue text, PR text, commit messages, and release notes in English
+
+### Writing style
+
+- In bullet and numbered lists, do not add a trailing period when an item contains one sentence
+- If an item contains two or more sentences, end every sentence with a period
+- Prefer concise, operational wording over marketing language
+
+### Sources of truth
+
+Use these sources when making changes or preparing repository-facing text:
+
+- This repository's current code, configuration, and passing tests
+- The ADAMANT organization governance repository: [Adamant-im/.github](https://github.com/Adamant-im/.github)
+- Recommended issue title prefixes: [Adamant-im discussion 5](https://github.com/orgs/Adamant-im/discussions/5)
+- Recommended labels for issues and discussions: [Adamant-im discussion 1](https://github.com/orgs/Adamant-im/discussions/1)
+- ADAMANT documentation: [docs.adamant.im](https://docs.adamant.im)
+- AIPs: [aips.adamant.im](https://aips.adamant.im) and [Adamant-im/AIPs](https://github.com/Adamant-im/AIPs)
+
+If sources disagree, prefer current repository behavior and passing tests as implementation truth, then document the mismatch instead of silently choosing a different rule.
+
+### Issue workflow
+
+When drafting issue text, titles, or recommendations for contributors:
+
+1. Search for existing issues first to avoid duplicates
+2. Prefer the organization issue forms when they are available
+3. Use a concise prefixed issue title
+4. Apply labels from the org label catalog, not ad hoc names
+5. Link related issues and PRs explicitly
+
+### Issue title prefixes
+
+Use one or two prefixes maximum.
+
+Common prefixes:
+
+- `[Bug]` for bugs, crashes, and unexpected behavior
+- `[Feat]` for new functionality
+- `[Enhancement]` for improvements without a brand new feature
+- `[Refactor]` for refactoring without intended behavior changes
+- `[Docs]` for documentation work
+- `[Test]` for test additions or test improvements
+- `[Chore]` for maintenance, tooling, dependencies, or CI work
+
+Additional useful prefixes in the ADAMANT organization:
+
+- `[Task]` for general tasks
+- `[Composite]` for multi-part work with sub-tasks
+- `[UX/UI]` for interface and user-experience work
+- `[Proposal]`, `[Idea]`, `[Discussion]` for idea-level topics that are often better suited for Discussions than Issues
+
+### Label policy
+
+- `labels.json` in the organization governance repository is the source of truth for label names, casing, descriptions, and colors
+- Keep default GitHub labels lowercase, such as `bug`, `enhancement`, and `documentation`
+- Keep custom organization labels capitalized when the org uses capitalized names, such as `Security`, `Privacy`, `Task`, `Composite task`, and `UX/UI`
+- For most issues, use a small but informative set: one type label, one or more domain labels, and an optional priority label when justified
+- Do not invent legacy workflow labels for tracking state when GitHub Projects already owns that workflow
+
+### PR conventions
+
+- Use the organization PR template sections when preparing PR text
+- Reference related issues with closing keywords when appropriate, for example `Closes #123`
+- Use Conventional Commit style for PR titles, for example `Docs: Update AI instructions`
+- Do not use issue-style square-bracket prefixes in PR titles
+- Keep PR title type aligned with the nature of the change, such as `Docs:`, `Fix:`, `Feat:`, `Refactor:`, `Test:`, or `Chore:`
+- Include testing or verification steps and mention meaningful risk areas
+
+### Common governance links
+
+- Governance repository: [Adamant-im/.github](https://github.com/Adamant-im/.github)
+- Prefix guidance: [Adamant-im discussion 5](https://github.com/orgs/Adamant-im/discussions/5)
+- Label guidance: [Adamant-im discussion 1](https://github.com/orgs/Adamant-im/discussions/1)
+- ADAMANT docs: [docs.adamant.im](https://docs.adamant.im)
+
 ## Scope
 
 This repository is the open-source base version of the bot.

--- a/.github/ai-agent-instructions.md
+++ b/.github/ai-agent-instructions.md
@@ -16,9 +16,20 @@ These repository-specific instructions extend the broader ADAMANT organization c
 
 ### Writing style
 
-- In bullet and numbered lists, do not add a trailing period when an item contains one sentence
+- In JSDoc param descriptions, bullet and numbered lists, do not add a trailing period when an item contains one sentence
 - If an item contains two or more sentences, end every sentence with a period
 - Prefer concise, operational wording over marketing language
+
+### JSDoc policy
+
+- Write JSDoc for functions you add or materially change
+- Document every function's purpose, parameters, and return value
+- Add `@param` entries for all parameters and describe meaningful value semantics, not only types
+- Add `@returns` when the return shape is not trivially obvious from the code
+- Reuse existing typedefs from `types/*.d.js` when possible instead of inventing ad hoc inline object descriptions
+- Keep JSDoc aligned with the repository's existing style and current behavior
+- When behavior changes, update the JSDoc in the same patch
+- Use Writing style guidelines
 
 ### Sources of truth
 
@@ -121,6 +132,15 @@ The current open-source version is intentionally narrower than the commercial pr
 - Database: MongoDB
 - API server: Express for debug and health routes
 - Typing style: JSDoc with `.d.js` files under `types/`
+
+## Documentation Expectations in Code
+
+JSDoc is the main documentation and typing mechanism in this repository.
+
+- Prefer documented functions over undocumented ones when touching code
+- Keep `@param`, `@returns`, and typedef references synchronized with implementation
+- For exchange adapters, document normalization rules and important status mappings
+- For helper functions with non-obvious behavior, document units, accepted formats, and failure behavior
 
 ## What Actually Starts
 

--- a/.github/ai-agent-instructions.md
+++ b/.github/ai-agent-instructions.md
@@ -1,0 +1,1167 @@
+# AI Agent Instructions for ADAMANT Market-Making Bot
+
+**Target Audience**: AI Coding Assistants (GitHub Copilot, Claude, Cursor, Windsurf, etc.)
+
+**Language Policy**: Developers communicate with AI in any language (English, Russian, etc.), but ALL code, documentation, comments, and commit messages MUST be in English only.
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#project-overview)
+2. [Development Priorities](#development-priorities)
+3. [Architecture Deep Dive](#architecture-deep-dive)
+4. [Critical System Patterns](#critical-system-patterns)
+5. [Reliability & Safety](#reliability--safety)
+6. [Data Flow & State Management](#data-flow--state-management)
+7. [Module Reference](#module-reference)
+8. [Development Workflow](#development-workflow)
+9. [Common Pitfalls](#common-pitfalls)
+10. [Refactoring Guidance](#refactoring-guidance)
+
+**Supplementary Guides:**
+
+- [Exchange Connector Guide](exchange-connector-guide.md) — Step-by-step instructions for creating and testing a new exchange connector (Spot REST, WebSocket, Perpetual/Futures)
+
+---
+
+## Project Overview
+
+### What Is This Bot?
+
+ADAMANT Trading Bot is a **self-hosted market-making bot** for cryptocurrency exchanges. It manages orders across 40+ exchanges to:
+
+- **Create trading volume** via wash trading in spread or order book
+- **Maintain spread and liquidity** with dynamic order book depth
+- **Build dynamic order books** with high-frequency live-like updates
+- **Watch and make token prices** — prevent manipulation, set price trends
+- **Support multiple modules and trading strategies** — ladder/grid, TWAP, balance equalizer, anti-gap, quote hunter, etc.
+
+**Website**: <https://marketmaking.app/>
+
+### Premium and Free Versions
+
+1. **Premium Version** (this repository): Full-featured, closed-source
+2. **Free Version**: <https://github.com/Adamant-im/adamant-tradebot> — Limited features, open-source
+
+**Custom Builds**: Clients (token issuers, crypto projects) order customized versions with specific premium features. Developers assemble a custom bot and push it to a separate repository. Keep code **modular** to facilitate building custom bots — every feature should be independently extractable.
+
+### Technology Stack
+
+- **Runtime**: Node.js >=20.19
+- **Database**: MongoDB 7 (with migrations)
+- **Language**: JavaScript (CommonJS modules, ES2021)
+- **Types**: JSDoc `@typedef` in `.d.js` files (not TypeScript `.d.ts`), for IDE support
+- **Communication**: ADAMANT Messenger, Telegram, Web UI, CLI
+- **Exchange APIs**: 40+ custom adapters (`trader_*.js`)
+- **Architecture**: Event-driven, single-threaded iteration loops
+
+---
+
+## Development Priorities
+
+These priorities guide ALL development decisions. When conflicts arise, higher priority wins.
+
+### 1. Reliability (Critical)
+
+**The bot must never crash. The system must be resilient to failures.**
+
+- **API connectors are robust** — they distinguish between requests that failed to reach the exchange, requests that returned an error, and successful responses
+- Always wrap exchange API calls in try-catch
+- **Graceful degradation** — if one module fails, others continue working
+- **No unhandled promise rejections** — every async operation has error handling
+- **Iteration loop protection** — `isPreviousIterationFinished` prevents race conditions
+- Retry failed requests with exponential backoff where appropriate
+
+### 2. Data Consistency (Critical)
+
+**Local order/balance data must match exchange state.**
+
+- **Database as source of truth** — NEVER place orders without immediate DB save
+- **Regular Cache invalidation** — call `orderUtils.clearCache()`
+- **Regular reconciliation** between local DB and exchange open orders
+- **Balance validation** — always check via `orderUtils.isEnoughCoins()` before placing orders
+- **False-empty-list protection** — detect when exchanges falsely return 0 orders, trigger emergency stop if needed
+- No duplicate orders — verify order doesn't exist before placing
+
+### 3. Safety (Critical)
+
+**The bot must not create unintended trading situations.**
+
+- **Amount/price validation** — always validate positive numbers before exchange calls
+- Respect exchange min/max limits for price and amount
+- Use correct decimals from `coin1Decimals` / `coin2DecimalsForStable`
+- **Balance protection** — never place orders exceeding available balance
+- **Rate limiting** — respect exchange API rate limits to avoid bans
+
+### 4. Correctness (Important)
+
+**Logic works according to documentation and expectations.**
+
+- Validate all inputs (prices, amounts, pairs) before processing
+- Check feature flags (`tradeParams.mm_is*Active`) before executing logic
+- Never hardcode exchange names — use `config.exchange` dynamically
+- Handle perpetual vs spot — check `config.perpetual` flag
+- Use proper log levels: `.log()` for info, `.warn()` for recoverable issues, `.error()` for failures
+
+### 5. Observability (Important)
+
+**Easy to understand what the bot is doing at any moment.**
+
+- **Comprehensive logging** — include module name, function name, and key parameters in all logs
+- **Structured error format**: `Error in functionName(${params}) of ${moduleName} module: ${error}`
+- **User notifications** — use `notify()` for important events (respects `silent_mode`)
+- **Fill statistics** — track order fills, volumes, VWAP in DB via `fillsEngine`
+- **Debug capabilities** — CLI mode for inspection without live trading
+
+### 6. Maintainability (Desirable)
+
+**Code is easy to read, change, and extend.**
+
+- **Incremental refactoring** — improve code quality with each touch (add JSDoc, extract soft dependencies, enhance error messages)
+- Follow existing patterns — match the style of surrounding code
+- **Soft dependencies** — use `utils.softRequire()` for optional modules
+- **Configuration-driven** — prefer config parameters over hardcoded behavior
+- Clear module boundaries — keep concerns separated
+
+### 7. Modularity & Exchange Agnosticism (Desirable)
+
+**Code works universally for all 40+ exchanges and is easy to extract into custom builds.**
+
+- Keep code **modular** to facilitate building custom bots easier — every feature should be independently extractable
+- Dynamic loading via `config.exchange` — never hardcode exchange names except in `trader_*.js` adapters
+- Exchange-specific quirks are abstracted inside trader adapters
+- All trader adapters expose the same interface with the same method signatures
+- Features are independently toggleable via `tradeParams` flags
+- Modules use cross-module communication via in-method `require()`, not module-level imports
+
+### Priority Trade-offs
+
+| Conflict | Resolution |
+| ---------- | ---------- |
+| **Reliability vs Speed** | Choose reliability — better to be slow than crash |
+| **Safety vs Features** | Choose safety — better to miss an opportunity than create a loss |
+| **Consistency vs Performance** | Choose consistency — cache carefully, invalidate aggressively |
+| **Correctness vs Convenience** | Choose correctness — validate thoroughly even if verbose |
+
+---
+
+## Architecture Deep Dive
+
+### System Architecture
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│                   ADAMANT Trading Bot                         │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │  ADAMANT API │  │  Telegram    │  │  Web UI /    │       │
+│  │  (Commands)  │  │  (Commands)  │  │  CLI         │       │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘       │
+│         └─────────────────┴─────────────────┘                │
+│                           │                                   │
+│                    ┌──────▼───────┐                           │
+│                    │  commandTxs  │ (Command Parser)          │
+│                    └──────┬───────┘                           │
+│                           │                                   │
+│         ┌─────────────────┼─────────────────┐                │
+│    ┌────▼─────┐           │          ┌──────▼──────┐         │
+│    │ Config   │           │          │ TradeParams │         │
+│    │ (JSONC)  │           │          │  (Dynamic)  │         │
+│    │ Immutable│           │          │  Runtime    │         │
+│    └──────────┘           │          └─────────────┘         │
+│                           │                                   │
+│  ┌────────────────────────▼─────────────────────────────┐    │
+│  │              Trade Modules (mm_*.js)                  │    │
+│  │ trader | liquidity | spread | orderbook | price_..   │    │
+│  │ antigap | cleaner | ladder | twap | quote_hunter     │    │
+│  │ fund_balancer | fund_supplier | balance_equalizer    │    │
+│  │ volatility_chart | volume_volatility | notifier      │    │
+│  └───────────┬──────────────────────────────────────────┘    │
+│              │                                                │
+│    ┌─────────▼─────────┐     ┌───────────────┐              │
+│    │  orderCollector   │◄────┤  orderUtils   │              │
+│    │  (Cancel/Cleanup) │     │  (Place/Cache)│              │
+│    └─────────┬─────────┘     └───────┬───────┘              │
+│              │                       │                       │
+│    ┌─────────▼───────────────────────▼───────────┐          │
+│    │      Exchange API Adapters (trader_*.js)     │          │
+│    │      + perpetualApi (for futures)            │          │
+│    │      + WebSocket streams (real-time data)    │          │
+│    └───────────────────┬─────────────────────────┘          │
+│                        │                                     │
+│    ┌───────────────────▼─────────────────────────┐          │
+│    │            MongoDB (DB.js)                    │          │
+│    │  ordersDb | fillsDb | filledStatsDb          │          │
+│    │  balancesHistory | systemDb                   │          │
+│    └──────────────────────────────────────────────┘          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Bootstrap Sequence (`app.js`)
+
+```text
+1. DB connects + runs migrations (modules/dbMigrations.js)
+   ↓
+2. ~1 second delay: Create tradeParams_{exchange}.js from template if missing
+   ↓
+3. ~5 seconds delay: Initialize services
+   - ADAMANT API socket (if passphrase provided)
+   - Health/Debug API (if api.port configured)
+   - Telegram bot (if manageTelegramBotToken set)
+   - Web UI API (if webui configured)
+   - Custom Strategy UI (if cs.ui.enabled)
+   - Comserver (if com_server enabled) — inter-bot communication
+   ↓
+4. Check inactivity period (heartbeat file)
+   - If offline too long → emergency pause (safety measure)
+   ↓
+5. Start ALL market-making modules via require('./trade/mm_*').run()
+   - Each module begins its own iteration loop
+   ↓
+6. Send startup notification
+```
+
+### Core Subsystems
+
+#### 1. Trade Modules (`trade/mm_*.js`)
+
+Independent market-making features and strategies. Most runs on its own iteration loop with randomized intervals. Most modules check `tradeParams.mm_isActive` as a global kill switch before doing work.
+
+#### 2. Exchange Abstraction (`trade/trader_*.js`)
+
+Factory functions that return a uniform API object. All adapters expose the same methods (see [Exchange Adapter Interface](#exchange-adapter-interface)). Loaded dynamically via:
+
+```javascript
+const TraderApi = require('./trader_' + config.exchange);
+const traderapi = TraderApi(config.apikey, config.apisecret, config.apipassword, log, ...);
+```
+
+#### 3. Order Lifecycle Engine
+
+- **orderUtils.js** — Order placement, balance checks, caching (open orders, order book, balances)
+- **orderCollector.js** — Centralized order cancellation and cleanup
+- **orderStats.js** — Statistics aggregation via MongoDB pipelines
+
+#### 4. Fills Processing (`helpers/fillsEngine.js`)
+
+Cumulative fill tracking engine with verification. Two DB collections:
+
+- `fillsDb` — event log of individual fills (produced by `orderUtils.updateOrders()`)
+- `filledStatsDb` — persistent accumulation of verified fills with VWAP calculation (survives restarts)
+
+#### 5. Configuration System
+
+- **`config.*.jsonc`** (immutable) — exchange-specific configs loaded once at startup
+- **`tradeParams_*.js`** (dynamic) — runtime-adjustable settings, modified by user commands
+
+#### 6. Command System (`modules/commandTxs.js`)
+
+Processes commands from ADAMANT Messenger, Telegram, CLI, and Web UI. Supports 39+ commands, feature enable/disable, emergency stop, confirmation mechanism.
+
+---
+
+## Critical System Patterns
+
+### 1. Iteration Loop Pattern
+
+**Most trade modules follow this exact pattern:**
+
+```javascript
+const moduleName = 'mm_moduleName';
+let isPreviousIterationFinished = true;
+
+module.exports = {
+  run() {
+    this.iteration();
+  },
+
+  async iteration() {
+    const interval = setPause(); // Randomized milliseconds
+
+    if (isPreviousIterationFinished) {
+      isPreviousIterationFinished = false;
+      try {
+        await this.doWork();
+      } catch (e) {
+        log.error(`Error in ${moduleName} iteration: ${e}`);
+      } finally {
+        isPreviousIterationFinished = true;
+      }
+    } else {
+      log.warn(`${moduleName}: Postponing iteration. Previous still in progress.`);
+    }
+
+    setTimeout(() => this.iteration(), interval);
+  },
+
+  async doWork() {
+    // Check master switch
+    if (!tradeParams.mm_isActive) return;
+    // Check module-specific switch
+    if (!tradeParams.mm_isModuleActive) return;
+    // Module logic...
+  }
+};
+```
+
+**Critical rules:**
+
+- `isPreviousIterationFinished` prevents overlapping executions (race conditions)
+- Randomized intervals (`setPause()`) avoid predictable API patterns
+- Single-threaded by design — no parallelism within a module
+- When disabled, iteration still runs (every ~3s) checking if reactivated
+
+### 2. Module Loading & Dynamic Dependencies
+
+Exchange-specific settings and APIs are loaded dynamically. **Never hardcode exchange names.**
+
+```javascript
+// ✅ CORRECT: Dynamic loading
+const tradeParams = require('./settings/tradeParams_' + config.exchange);
+const TraderApi = require('./trader_' + config.exchange);
+const traderapi = TraderApi(config.apikey, config.apisecret, ...);
+
+// ❌ WRONG: Hardcoded exchange
+const traderapi = require('./trader_binance')(apikey, apisecret);
+```
+
+### 3. Cross-Module Communication
+
+**Regularly modules load other modules INSIDE methods, not at module level.** This prevents circular requires and allows feature toggling:
+
+```javascript
+// ✅ CORRECT: Load inside method (soft dependency)
+async function updateOrderBook() {
+  if (tradeParams.mm_isLiquidityActive) {
+    const lp = require('./mm_liquidity_provider');
+    await lp.updateLiquidityAfterPriceChange(side, callerName);
+  }
+}
+
+// ❌ WRONG: Load at module level (hard dependency)
+const lp = require('./mm_liquidity_provider');
+```
+
+For truly optional modules, use `utils.softRequire()`:
+
+```javascript
+const vv = utils.softRequire('./mm_volume_volatility');
+if (vv && tradeParams.mm_isVolumeVolatilityActive) {
+  const coefficient = vv.getVolumeVolatilityCoefficient();
+}
+```
+
+### 4. Two-Account (2-Key) Trading
+
+Some modules support a second exchange account (`config.apikey2` / `config.apisecret2`) to avoid self-trade restrictions:
+
+```javascript
+const TraderApi = require('./trader_' + config.exchange);
+const traderapi = TraderApi(config.apikey, config.apisecret, ...);
+
+let traderapi2;
+if (config.apikey2) {
+  traderapi2 = TraderApi(config.apikey2, config.apisecret2, ..., /* accountNo */ 2, ...);
+  traderapi2.isSecondAccount = true;
+}
+
+const useSecondAccount = traderapi2 && !isPerpetual;
+// Account 1 places maker order, Account 2 takes it
+const makerApi = traderapi;
+const takerApi = useSecondAccount ? traderapi2 : traderapi;
+```
+
+Modules with 2-account support: mm_trader, mm_price_maker, mm_quote_hunter, mm_twap, mm_cleaner, mm_fund_balancer.
+
+### 5. Config vs TradeParams
+
+| Aspect | `config` (configReader.js) | `tradeParams` |
+| -------- | --------------------------- | --------------- |
+| Source | `config.*.jsonc` | `tradeParams_{exchange}.js` |
+| Mutability | **Immutable** after load | **Dynamic** — modified at runtime |
+| Contains | API keys, exchange, pair, services | Feature flags, amounts, intervals, strategies |
+| Modified by | Only on restart | User commands (`/enable`, `/params`), saved to file |
+| Access | `require('./modules/configReader')` | `require('./settings/tradeParams_' + config.exchange)` |
+
+**Important derived config properties:**
+
+- `config.exchange` — lowercase exchange name
+- `config.exchangeName` — original case exchange name
+- `config.defaultPair` — `config.perpetual || config.pair`
+- `config.coin1`, `config.coin2` — pair components
+- `config.dev` — development mode flag
+- `config.hasAdmPassphrase` — whether ADAMANT passphrase is configured
+- `config.bot_id` — unique bot identifier (`pair@exchange-account`)
+
+### 6. Features vs Order Purposes
+
+**Features** (`botFeatures` in `commandTxs.js`) are user-controllable capabilities. **Order Purposes** are internal order type identifiers stored in `ordersDb`. They are NOT 1:1.
+
+Some features create orders with a specific purpose. Some features DON'T have their own purpose — they modify behavior of other modules or set parameters.
+
+| Feature | tradeParam | Purpose | Description |
+| -------- | ----------- | --------- | ------------- |
+| `t` | `mm_isTraderActive` | `t` | Making trading volume |
+| `ob` | `mm_isOrderBookActive` | `ob`, `obs` | Dynamic order book building |
+| `liq` | `mm_isLiquidityActive` | `liq` | Liquidity and spread maintenance |
+| `sm` | `mm_isSpreadMaintainerActive` | `sm` | Spread maintainer |
+| `ag` | `mm_isAntigapActive` | `ag` | Order book anti-gap |
+| `cl` | `mm_isCleanerActive` | `cl` | Order book cleaner |
+| `pw` | `mm_isPriceWatcherActive` | `pw` | Price watching |
+| `ld` | `mm_isLadderActive` | `ld` | Ladder/grid trading |
+| `qh` | `mm_isQuoteHunterActive` | `qh` | Quote hunter |
+| `tw` | `t_isTwapActive` | `tw` | TWAP orders |
+| `be` | `mm_isBalanceEqualizerActive` | `be` | Balance equalizer |
+| `on` | `mm_isOrderNotifierActive` | — | Order notifier (monitoring only) |
+| `bw` | `mm_isBalanceWatcherActive` | — | Balance watching (monitoring only) |
+| `vc` | `mm_isVolatilityActive` | — | Volatility chart (modifies `t` behavior) |
+| `vv` | `mm_isVolumeVolatilityActive` | — | Volume volatility (modifies `t` behavior) |
+| `sp` | `mm_priceSupportLowPrice` | — | Support price (sets param to 0) |
+| `pmv` | `mm_isPriceChangeVolumeActive` | — | PM/PW additional volume |
+| `fb` | `mm_isFundBalancerActive` | — | Fund balancer (adjusts `mm_buyPercent`) |
+
+Additional order purposes (not direct features): `fs` (fund supplier), `pm` (price maker), `tb` (trade bot manual), `man` (manual).
+
+Each feature has a `requires` field for dependencies (e.g., `'vc'` requires `mm_isTraderActive`).
+
+Query orders by purpose:
+
+```javascript
+const smOrders = await ordersDb.find({
+  isProcessed: false,
+  purpose: 'sm',
+  pair: config.pair,
+  exchange: config.exchange
+});
+```
+
+### 7. Order Placement Flow
+
+Every order placement must follow this sequence:
+
+```javascript
+// 1. Parse market for decimals
+const { coin1Decimals, coin2DecimalsForStable } = orderUtils.parseMarket(pair);
+
+// 2. Calculate amount and price
+const amount = baseAmount.toFixed(coin1Decimals);
+const price = quotePrice.toFixed(coin2DecimalsForStable);
+
+// 3. Validate balance
+const balanceCheck = await orderUtils.isEnoughCoins(
+  side, formattedPair, baseAmount, quoteAmount, purpose, '', moduleName, api
+);
+if (!balanceCheck.result) {
+  log.warn(`${moduleName}: ${balanceCheck.message}`);
+  return;
+}
+
+// 4. Place order on exchange
+const result = await traderapi.placeOrder(side, pair, price, amount, 1);
+if (!result?.orderId) {
+  log.warn(`${moduleName}: Failed to place ${side} order`);
+  return;
+}
+
+// 5. Save to DB IMMEDIATELY
+const order = new db.ordersDb({
+  _id: result.orderId,
+  side, pair, price: +price,
+  coin1Amount: +amount, coin2Amount: quoteAmount,
+  purpose, exchange: config.exchange, date: Date.now(),
+  isProcessed: false
+}, true); // true = save immediately
+
+// 6. Clear cache
+orderUtils.clearCache(`${moduleName}/functionName`);
+
+// 7. Log success
+log.info(`${moduleName}: Placed ${side} order for ${amount} ${coin1} at ${price} ${coin2}`);
+```
+
+### 8. Order Cancellation
+
+**Always use `orderCollector.clearOrderById()` — it handles DB update, cache invalidation, and logging:**
+
+```javascript
+// ✅ CORRECT
+const result = await orderCollector.clearOrderById(
+  orderId, pair, side, `${moduleName}/reason`, reasonDescription, reasonObj, api
+);
+
+// ❌ WRONG — missing DB update, cache invalidation, logging
+await traderapi.cancelOrder(orderId, side, pair);
+```
+
+### 9. Caching Pattern
+
+Three caches in `orderUtils` for the primary account only:
+
+```javascript
+// Cache duration: constants.REST_DATA_CACHE_MS (1000ms)
+orderUtils.getOpenOrdersCached(pair, moduleName)    // Open orders
+orderUtils.getOrderBookCached(pair, moduleName)     // Order book
+orderUtils.getBalancesCached(nonzero, moduleName)   // Balances
+```
+
+- Socket data bypasses cache when available
+- Second account / perpetual API always makes fresh requests
+- **Always clear cache after modifying orders**: `orderUtils.clearCache(callerName)`
+
+### 10. Error Handling Pattern
+
+```javascript
+async function someFunction(param1, param2) {
+  const paramString = `param1: ${param1}, param2: ${param2}`;
+
+  try {
+    const result = await traderapi.someMethod(param1, param2);
+
+    if (!result || !result.success) {
+      log.warn(`${moduleName}: Failed someMethod(${paramString})`);
+      notify(`Failed operation`, 'warn', config.silent_mode);
+      return;
+    }
+
+    log.info(`${moduleName}: Successfully executed someMethod(${paramString})`);
+
+  } catch (e) {
+    log.error(`Error in someFunction(${paramString}) of ${moduleName} module: ${e}`);
+    notify(`Error in ${moduleName}`, 'error', config.silent_mode);
+  }
+}
+```
+
+---
+
+## Reliability & Safety
+
+### Exchange API Error Handling in Adapters
+
+Each `trader_*.js` adapter has a `handleResponse()` function that classifies HTTP responses:
+
+- **5xx, 429** — Temporary errors → reject → retry
+- **401, 403** — Authentication errors → log error, check API keys
+- **400** — Bad params → resolve with error data for caller to handle
+- **200** — Success → process data
+
+### False-Empty-List Protection
+
+`orderUtils.updateOrders()` includes a safety heuristic:
+
+1. If exchange returns 0 open orders but DB has many unprocessed orders → suspicious
+2. Verifies via `getOrderDetails()` API if available
+3. If confirmed suspicious → triggers `emergencyStop()` to pause all trading
+4. Prevents accidentally marking all orders as filled when exchange API glitches
+
+### Emergency Stop
+
+`commandTxs.commands.emergencyStop(callerName, details)`:
+
+- Sets `mm_isActive = false`
+- Saves config immediately
+- Sends **priority notification** via all channels
+- Called by:
+  - User command (`/emergency_stop`)
+  - `orderUtils.updateOrders()` on suspicious API behavior
+  - Bootstrap `checkInactivityPeriod()` if bot was offline too long
+
+### Inactivity Protection
+
+On startup, the bot checks a heartbeat file (`logs/heartbeat`):
+
+- Written every 60 seconds during normal operation
+- If the gap between last heartbeat and now exceeds `config.pauseAfterInactivity` (default: 6h):
+  - Bot starts in **paused state** (emergency stop)
+  - Prevents unexpected behavior after extended downtime
+  - Operator must manually review and `/start`
+
+---
+
+## Data Flow & State Management
+
+### Order State Lifecycle
+
+Orders have these status flags:
+
+| Field | When True |
+| ------- | ----------- |
+| `isProcessed` | Filled, cancelled, or disappeared from exchange |
+| `isExecuted` | Filled or partly filled (has executed amount) |
+| `isClosed` | Same as isProcessed — order is no longer active |
+| `isCancelled` | Bot explicitly cancelled it |
+| `isExpired` | Order lifetime exceeded |
+| `isNotFound` | Missing from exchange's open orders list |
+
+**Lifecycle:**
+
+1. **Placed** → `{ isProcessed: false, isExecuted: false }`
+2. **Partially filled** → `{ isProcessed: false, isExecuted: true }`
+3. **Fully filled** → `{ isProcessed: true, isExecuted: true, isClosed: true, (isNotFound: true in exchange open orders) }`
+4. **Cancelled by bot** → `{ isProcessed: true, isCancelled: true, isClosed: true }`
+
+### Fills Processing Pipeline
+
+```text
+1. orderUtils.updateOrders() detects fills
+   → fillsEngine.addFill() builds fill data
+   → fillsEngine.addFillsDbRecord() saves to fillsDb { isProcessed: false }
+
+2. Trade modules call fillsEngine.processFills():
+   → Read unprocessed fillsDb records
+   → Verify each fill via traderapi.getOrderDetails()
+   → Confirmed fills: aggregate into filledStatsDb via MongoDB $inc
+   → Mark fillsDb records as isProcessed: true
+
+3. fillsEngine.getStats() returns VWAP metrics:
+   → VWAP per side (buy/sell)
+   → VWAP Spread
+   → Cashflow PnL, Inventory change
+   → Mark-to-Market PnL
+```
+
+### Fill Verification Policy
+
+When `fillsEngine.verifyOrderFilled()` checks a fill via exchange API:
+
+- No `getOrderDetails()` method → assume filled (can't disprove)
+- Status `filled` → confirmed
+- Status `new`/`part_filled`/`cancelled` → rejected (mistakenly marked)
+- Status `unknown` → treat as confirmed (can't disprove)
+- API failure → return `undefined` (retry later)
+
+### Balance Tracking
+
+```text
+1. orderUtils.getBalancesCached() → exchange API → cache
+2. balancesHistory.saveSnapshotIfChanged() → persist to DB
+3. mm_balance_watcher.guardBalances() → compare to reference, alert on anomalies
+```
+
+---
+
+## Module Reference
+
+### Trade Modules
+
+#### Volume & Trading
+
+| Module | File | Purpose | Interval | Description |
+| -------- | ------ | --------- | ---------- | ------------- |
+| **Trader** | `mm_trader.js` | `t` | Configurable | Creates trading volume. Policies: `spread`, `orderbook`, `optimal`, `depth`, `wash`. Supports 2-account and perpetual. |
+| **TWAP** | `mm_twap.js` | `tw` | Configurable | Time-Weighted Average Price execution. Splits large order over time. **Independent from `mm_isActive`** — runs even when bot is stopped. |
+
+#### Order Book Management
+
+| Module | File | Purpose | Interval | Description |
+| -------- | ------ | --------- | ---------- | ------------- |
+| **Order Book Builder** | `mm_orderbook_builder.js` | `ob` | 2-6s | Places/removes orders for dynamic, live-like order book. Supports perpetual. |
+| **Order Book Spread** | `mm_orderbook_spread.js` | `obs` | 1-4s | Places orders ahead of detected big orders in the book. Spot only. |
+| **Liquidity Provider** | `mm_liquidity_provider.js` | `liq` | 10-20s | Places orders deeper in book. Features: spread support, safe liquidity (VWAP-based), flowing liquidity. Spot only. |
+| **Spread Maintainer** | `mm_spread_maintainer.js` | `sm` | 1-2min | Keeps bid-ask spread tight with short-lived orders (10-30min lifetime). Also called by other modules. Spot only. |
+| **Anti-gap** | `mm_antigap.js` | `ag` | 15-25s | Fills gaps in order book where price intervals exceed average. Max 50 orders. Spot only. |
+
+#### Price Management
+
+| Module | File | Purpose | Interval | Description |
+| -------- | ------ | --------- | ---------- | ------------- |
+| **Price Watcher** | `mm_price_watcher.js` | `pw` | 15-30s | Monitors price within a range from various sources. Actions: `fill` (buy/sell to restore) or `prevent` (block other modules). Validates against InfoService. |
+| **Price Maker** | `mm_price_maker.js` | — | 30s-1min | Drives price toward target. Supports 2-account. Has backstep logic for realistic charts. |
+| **Volatility Chart** | `mm_volatility_chart.js` | — | — | Sets price trends mimicking top-coin charts. Works within Price Watcher's range. Sets targets for Price Maker. |
+| **Volume Volatility** | `mm_volume_volatility.js` | — | 4-5min | Calculates volume coefficient (0.25×-4×) based on recent price changes. Adjusts mm_trader amounts. Spot only. |
+
+#### Balance & Fund Management
+
+| Module | File | Purpose | Interval | Description |
+| -------- | ------ | --------- | ---------- | ------------- |
+| **Cleaner** | `mm_cleaner.js` | `cl` | 4-9s | Anti-cheat: detects/removes small manipulation orders. Policies: `preventCheating`, `takeAll`, `minimumSpread`, `smallSpread`. Spot only. |
+| **Quote Hunter** | `mm_quote_hunter.js` | `qh` | 5-10s | Accumulates quote currency by selling base at favorable rates. 2-account support. Spot only. |
+| **Balance Equalizer** | `mm_balance_equalizer.js` | `be` | 1-3min | Keeps coin1/coin2 near-equal in USD value. Strategies: `bp` (adjust buyPercent) or `market` (place orders). Single-key only. Spot only. |
+| **Fund Balancer** | `mm_fund_balancer.js` | — | 3-7min | Adjusts `mm_buyPercent` to keep coin2 balanced across 2 accounts. 2-key only. Spot only. |
+| **Fund Supplier** | `mm_fund_supplier.js` | `fs` | 1-3min | Exchanges coins to maintain minimum balances for configured pairs. Uses `config.fund_supplier` settings. Spot only. |
+| **Ladder** | `mm_ladder.js` | `ld` | — | Grid/ladder trading. When closest order fills, places mirrored order on opposite side. Supports two independent ladder instances (`ld1`, `ld2`). Complex state machine with `LADDER_STATES`. |
+
+#### Monitoring
+
+| Module | File | Purpose | Interval | Description |
+| -------- | ------ | --------- | ---------- | ------------- |
+| **Balance Watcher** | `mm_balance_watcher.js` | — | — | Compares current balances to reference timestamp. Alerts on abnormal coin2 decrease or expected value drop. No orders. |
+| **Order Notifier** | `mm_order_notifier.js` | — | 5-15s | Monitors order book for significant third-party orders placed/removed. No orders. |
+
+### Cross-Module Call Chain
+
+Key inter-module dependencies (called inside methods, not at module level):
+
+```text
+mm_trader → mm_spread_maintainer.maintainSpreadAfterPriceChange()
+mm_price_maker → mm_spread_maintainer.maintainSpreadAfterPriceChange()
+mm_price_watcher → mm_spread_maintainer.maintainSpreadAfterPriceChange()
+mm_quote_hunter → mm_spread_maintainer.maintainSpreadAfterPriceChange()
+mm_spread_maintainer → mm_liquidity_provider.updateLiquidityAfterPriceChange()
+orderUtils.getBalancesCached() → mm_balance_watcher.guardBalances() (via softRequire)
+```
+
+### Core Modules
+
+| Module | File | Purpose |
+| -------- | ------ | --------- |
+| **configReader** | `modules/configReader.js` | Loads and validates `config.*.jsonc`. Immutable after load. Derives `config.exchange`, `config.pair`, `config.coin1/coin2`, etc. |
+| **DB** | `modules/DB.js` | MongoDB connection, collection setup with indexes, migration runner. Exports collection helpers. |
+| **commandTxs** | `modules/commandTxs.js` | Command parser for ADAMANT/Telegram/CLI/WebUI. 39+ commands, feature management, emergency stop, confirmation mechanism. |
+| **adamantApi** | `modules/adamantApi.js` | ADAMANT blockchain integration and WebSocket for receiving commands. |
+| **perpetualApi** | `modules/perpetualApi.js` | Singleton factory for perpetual/futures contract adapters. Loads from `trade/api/contract/{exchange}PerpetualApi.js`. Returns `null` if `config.perpetual` is falsy. |
+| **Store** | `modules/Store.js` | Persistent state management via `systemDb`. Tracks last processed ADM block height, generic get/set for system fields. |
+| **eventEmitter** | `modules/eventEmitter.js` | Event bus with one event: `'parameters:update'` — broadcast when config changes. |
+| **botInterchange** | `modules/botInterchange.js` | Inter-bot communication via Socket.IO. Allows bots on different exchanges/pairs to coordinate. AES-encrypted. |
+| **dbMigrations** | `modules/dbMigrations.js` | Schema migrations. Current: renames legacy `type` field to `side` in orders. Errors halt startup. |
+
+### Helper Modules
+
+| Module | File | Purpose |
+| -------- | ------ | --------- |
+| **const** | `helpers/const.js` | Time constants (MINUTE, HOUR, DAY), policy lists, regex patterns, thresholds, cache durations. |
+| **utils** | `helpers/utils.js` | ~3600 lines of utilities: `parseSmartTime()`, `parseSmartNumber()`, `softRequire()`, `watchConfig()`, `saveConfig()`, logging helpers, math, formatting. |
+| **log** | `helpers/log.js` | Logging with levels: `none < error < warn < info < log < debug < trace`. Writes to `./logs/{date}.log` with ANSI colors. Writes heartbeat file every 60s. |
+| **notify** | `helpers/notify.js` | Multi-channel notifications: ADAMANT, Telegram, Slack, Discord, Email. Supports priority channels, silent mode, email aggregation. |
+| **fillsEngine** | `helpers/fillsEngine.js` | Fill verification, VWAP calculation, PnL metrics. Cumulative stats from a reset point. |
+| **dbModel** | `helpers/dbModel.js` | Lightweight ORM wrapper. Static: `find()`, `findOne()`, `count()`, `updateOne()`, `deleteOne()`, `aggregate()`. Instance: `save()`, `update()`. |
+| **balancesHistory** | `helpers/balancesHistory.js` | Records balance snapshots to DB when changes are detected. |
+
+### Exchange Adapter Interface
+
+All `trader_*.js` files are factory functions with this signature:
+
+```javascript
+module.exports = (apiKey, secretKey, pwd, log, publicOnly, loadMarket,
+                  useSocket, useSocketPull, accountNo, coin1, coin2) => { ... }
+```
+
+**Returned object methods:**
+
+| Method | Purpose |
+| -------- | --------- |
+| `getMarkets(pair?)` | Fetch/cache trading pairs info |
+| `getCurrencies(coin?)` | Fetch/cache currency info |
+| `marketInfo(pair)` | Get cached market info for a pair |
+| `features(pair?)` | Exchange capability flags |
+| `getBalances(nonzero?, accountType?)` | Account balances |
+| `getOpenOrders(pair)` | List open orders |
+| `getOrderDetails(orderId, pair)` | Single order status |
+| `placeOrder(side, pair, price, amount, limit, coin2Amount)` | Place buy/sell order |
+| `cancelOrder(orderId, side, pair)` | Cancel one order |
+| `cancelAllOrders(pair)` | Cancel all orders for pair |
+| `getOrderBook(pair, limit)` | Order book depth |
+| `getRates(pair)` | 24h ticker/rates |
+| `getTradesHistory(pair, limit)` | Recent trades |
+| `getCandlesHistory(pair, timeframe, since, limit)` | OHLCV candles |
+| `getDepositAddress(coin)` | Deposit address |
+| `getFees(coinOrPair)` | Trading/withdrawal fees |
+| `transfer(coin, from, to, amount)` | Internal transfer |
+| `withdraw(address, amount, coin, fee, network)` | External withdrawal |
+
+**`features()` capability flags** include: `getMarkets`, `placeMarketOrder`, `selfTradeProhibited`, `orderNumberLimit`, `isDemo`, `supportTransferBetweenAccounts`, etc.
+
+### Database Collections
+
+```javascript
+const db = require('./modules/DB');
+
+db.ordersDb         // Orders: find(), findOne(), save(), updateOne(), count()
+db.fillsDb          // Fill event log
+db.filledStatsDb    // Persistent fill statistics (VWAP accumulators)
+db.balancesHistory  // Balance snapshots (raw MongoDB collection)
+db.systemDb         // System state (last block height, etc.)
+db.incomingTxsDb    // ADAMANT commands
+db.incomingTgTxsDb  // Telegram commands
+db.incomingCLITxsDb // CLI commands
+db.webTerminalMessages // Web UI messages (raw collection)
+```
+
+**DB Model methods** (from `helpers/dbModel.js`):
+
+| Method | Type | Description |
+| -------- | ------ | ------------- |
+| `Model.find(query)` | Static | Returns array of Model instances |
+| `Model.findOne(query)` | Static | Returns single Model instance or null |
+| `Model.count(query)` | Static | Returns count |
+| `Model.updateOne({ filter, update, options })` | Static | MongoDB updateOne |
+| `Model.deleteOne(query)` | Static | Deletes one document |
+| `Model.aggregate(pipeline)` | Static | MongoDB aggregation |
+| `instance.save()` | Instance | Insert or upsert (depends on `_id` presence) |
+| `instance.update(obj, shouldSave)` | Instance | Merge properties, optionally persist |
+
+### Type System
+
+Types are defined as JSDoc `@typedef` in `types/*.d.js` files (not TypeScript):
+
+- **Generic exchange types**: `orders.d.js`, `depth.d.js`, `rates.d.js`, `markets.d.js`, `assets.d.js`, `fills.d.js`, etc.
+- **Bot-internal types**: `types/bot/parsedMarket.d.js`, `types/bot/orderBookInfo.d.js`, `types/bot/orderMetrics.d.js`, etc.
+- **Exchange-specific types**: `types/binance/`, `types/bybit/`, `types/kraken/`, etc.
+- **Contract types**: `types/contracts/` — perpetual contract–specific types
+
+### Custom Strategy System (`trade/cs/`)
+
+Self-contained sub-application with its own `package.json`. Provides:
+
+- Technical-indicator-based strategies (RSI, etc.)
+- Backtesting with historical data
+- Paper trading
+- Live trading with configurable parameters
+- Separate Web UI (`cs.ui`)
+
+Managed by `trade/cs_manager.js`. Installed via `postinstall` script.
+
+---
+
+## Development Workflow
+
+### Mandatory Connector Delivery Rules (AI Agents)
+
+When creating or refactoring an exchange connector, AI agents MUST follow these rules:
+
+1. Add detailed JSDoc and typedef usage from `types/*.d.js` in both API and trader connector files.
+2. Create exchange-specific endpoint response types under `types/{exchange}/` with realistic `@example` blocks.
+3. Add direct official endpoint documentation links in JSDoc for each API method.
+4. Avoid permissive fallback masking (`?.list || []`) that hides malformed responses; validate shape explicitly.
+5. Use `marketInfo()` metadata in candles normalization code.
+6. Use exchange bulk cancellation endpoint for `cancelAllOrders()` when available.
+7. Reuse helper logic from `helpers/utils.js`; if generic helper is missing, extract it there.
+8. Provide detailed test evidence (raw exchange payload + normalized output), including all `getOrderDetails` status mappings: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
+9. Save test result reports to separate files for each mode: `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-mock) ... .md` for mock runs and `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-live) ... .md` for live runs.
+10. `trade/settings/tradeParams_{exchange}.js` must be a full copied object (no re-export from `tradeParams_Default`).
+11. Keep all Markdown docs lint-clean; follow markdownlint rules (including `MD022`, `MD032`, `MD007`, `MD034`, `MD040`).
+12. Do not use ambiguous `default` typedef names in exchange-specific types; use human-readable exchange-prefixed names (for example, `DextradeSymbols`, `DextradeOrder`) and import them explicitly.
+13. In one-line parameter/property/list descriptions use no trailing period for a single sentence. If description contains two or more sentences, keep terminal periods for each sentence.
+
+### Commands
+
+```bash
+npm start              # Production (uses config.default.jsonc or config.jsonc)
+npm run start:config -- <name>  # Run with custom config name: config.<name>.jsonc
+npm run start:dev      # Development (uses config.dev.jsonc, config.dev = true)
+npm run cli            # CLI mode (interactive commands, no ADAMANT passphrase)
+npm run cli:config -- <name>    # CLI mode with custom config name
+npm run cli:dev        # CLI mode with dev config
+npm run clear          # Clear database (drops all collections) for default config
+npm run clear:config -- <name> clear_db  # Clear database for custom config
+npm test               # Run Jest tests
+npm run lint           # ESLint check (visualstudio format)
+npm run lint:fix       # ESLint auto-fix
+```
+
+### Config File Selection
+
+The bot selects config based on CLI argument:
+
+- `npm start` → `config.default.jsonc`
+- `npm run start:config -- {name}` → `config.{name}.jsonc`
+- `npm run start:dev` → `config.dev.jsonc` (treated as dev config)
+- `node app.js {name}` → `config.{name}.jsonc` (direct launch, equivalent to `start:config`)
+
+### Adding a New Exchange
+
+See the comprehensive **[Exchange Connector Guide](exchange-connector-guide.md)** for step-by-step instructions covering:
+
+- Plain API client (`trade/api/{exchange}_api.js`) with `handleResponse()`, `publicRequest()`, `protectedRequest()`
+- Error descriptions file (`trade/api/{exchange}_errors.js`)
+- Trader adapter (`trade/trader_{exchange}.js`) with all required methods and return shapes
+- Config registration and exchange name setup
+- Testing each method individually (request processing, balances, orders, trades, etc.)
+- WebSocket connector (public, private, pull)
+- Perpetual/Futures connector with module compatibility matrix
+- Automated Jest tests with mock adapter
+- MM simulation testing
+
+**Quick summary:**
+
+1. **Create API client**: `trade/api/{exchange}_api.js` + `trade/api/{exchange}_errors.js`
+2. **Create trader adapter**: `trade/trader_{exchange}.js` — implement all methods from the [Exchange Adapter Interface](#exchange-adapter-interface)
+3. **Create config**: `config.{exchange}_test.jsonc`
+4. **Add exchange name** to the `exchanges` array in `config.default.jsonc`
+5. **(Optional)** Create exchange-specific trade params override: `trade/settings/tradeParams_{exchange}.js`
+6. **Test**: `node app.js {config_name}` — follow the testing checklist in the guide
+
+### File Structure
+
+```text
+adamant-tradebot-me/
+├── app.js                         # Bootstrap entry point
+├── config.*.jsonc                 # Exchange-specific configs (immutable)
+├── package.json
+├── api/                           # Web UI API (REST endpoints)
+├── bin/
+│   └── cli.js                     # CLI entry point
+├── helpers/
+│   ├── const.js                   # Constants (time, thresholds, policies)
+│   ├── log.js                     # Logging + heartbeat
+│   ├── notify.js                  # Multi-channel notifications
+│   ├── utils.js                   # Utilities (~3600 lines)
+│   ├── fillsEngine.js             # Fill verification, VWAP
+│   ├── dbModel.js                 # Lightweight MongoDB ORM
+│   └── balancesHistory.js         # Balance snapshots
+├── modules/
+│   ├── configReader.js            # Config loader (immutable)
+│   ├── DB.js                      # MongoDB setup + migrations
+│   ├── commandTxs.js              # Command parser + features
+│   ├── adamantApi.js              # ADAMANT blockchain integration
+│   ├── perpetualApi.js            # Perpetual contracts API factory
+│   ├── Store.js                   # Persistent system state
+│   ├── eventEmitter.js            # Event bus
+│   ├── botInterchange.js          # Inter-bot communication
+│   └── dbMigrations.js            # DB schema migrations
+├── trade/
+│   ├── mm_*.js                    # Market-making modules (18 modules)
+│   ├── trader_*.js                # Exchange API adapters (40+ exchanges)
+│   ├── orderCollector.js          # Order cancellation/cleanup
+│   ├── orderUtils.js              # Order helpers, caching, balance checks
+│   ├── orderStats.js              # Statistics aggregation
+│   ├── cs_manager.js              # Custom strategy manager
+│   ├── api/                       # Exchange-specific API clients
+│   │   ├── binance_api.js
+│   │   └── contract/              # Perpetual contract adapters
+│   └── settings/
+│       ├── tradeParams_Default.js # Template for trade parameters
+│       └── tradeParams_*.js       # Exchange-specific overrides
+├── telegramBot/                   # Telegram bot integration
+├── types/                         # JSDoc type definitions (.d.js)
+│   ├── bot/                       # Bot-internal types
+│   ├── contracts/                 # Contract-specific types
+│   ├── binance/, bybit/, ...      # Exchange-specific raw API types
+│   └── *.d.js                     # Generic exchange types
+└── .github/
+    └── ai-agent-instructions.md   # This file
+```
+
+### Code Style
+
+- ESLint with Google config + custom rules
+- Single quotes, template literals allowed
+- Max line length: 133 (excluding comments, strings, URLs)
+- Prefer arrow callbacks, object shorthand
+- `eqeqeq: 'always'` — strict equality
+- Ignored paths: `trade/settings/`, `trade/tests/`, `trade/cs/test/`
+
+---
+
+## Common Pitfalls
+
+### ❌ Hardcoding Exchange Names
+
+```javascript
+// ❌ WRONG
+const traderapi = require('./trader_binance')(...);
+
+// ✅ CORRECT
+const traderapi = require('./trader_' + config.exchange)(...);
+```
+
+### ❌ Placing Orders Without DB Save
+
+```javascript
+// ❌ WRONG — no DB persistence, system loses track
+const result = await traderapi.placeOrder(side, pair, price, amount);
+
+// ✅ CORRECT — save immediately
+const result = await traderapi.placeOrder(side, pair, price, amount);
+const order = new db.ordersDb({ _id: result.orderId, ... }, true);
+```
+
+### ❌ Skipping `isPreviousIterationFinished`
+
+```javascript
+// ❌ WRONG — overlapping iterations cause race conditions
+async iteration() {
+  await this.doWork();
+  setTimeout(() => this.iteration(), interval);
+}
+
+// ✅ CORRECT
+if (isPreviousIterationFinished) {
+  isPreviousIterationFinished = false;
+  await this.doWork();
+  isPreviousIterationFinished = true;
+}
+```
+
+### ❌ Mixing Perpetual and Spot
+
+```javascript
+// ❌ WRONG — always using spot API
+const traderapi = require('./trader_' + config.exchange)(...);
+
+// ✅ CORRECT — check config.perpetual
+const isPerpetual = Boolean(config.perpetual);
+const traderapi = isPerpetual
+  ? require('./modules/perpetualApi')()
+  : TraderApi(config.apikey, config.apisecret, ...);
+```
+
+### ❌ Wrong Decimals
+
+```javascript
+// ❌ WRONG — hardcoded decimals
+const amount = baseAmount.toFixed(8);
+
+// ✅ CORRECT — use parsed market info
+const { coin1Decimals } = orderUtils.parseMarket(pair);
+const amount = baseAmount.toFixed(coin1Decimals);
+```
+
+### ❌ Forgetting Cache Invalidation
+
+```javascript
+// ❌ WRONG — stale cache after modification
+await traderapi.placeOrder(side, pair, price, amount);
+
+// ✅ CORRECT — invalidate cache
+await traderapi.placeOrder(side, pair, price, amount);
+orderUtils.clearCache(`${moduleName}/placedOrder`);
+```
+
+### ❌ Hard Dependencies at Module Level
+
+```javascript
+// ❌ WRONG — creates hard dependency, prevents feature toggling
+const lp = require('./mm_liquidity_provider');
+
+// ✅ CORRECT — soft dependency inside method
+if (tradeParams.mm_isLiquidityActive) {
+  const lp = require('./mm_liquidity_provider');
+  await lp.updateLiquidityAfterPriceChange(side, callerName);
+}
+```
+
+### ❌ Confusing Feature and Purpose
+
+```javascript
+// ❌ WRONG — 'vc' feature has no order purpose
+const orders = await db.ordersDb.find({ purpose: 'vc' }); // No such purpose!
+
+// ✅ CORRECT — 'vc' modifies trader behavior
+const coefficient = require('./mm_volatility_chart').getVolatilityCoefficient();
+```
+
+### ❌ Logging Sensitive Data
+
+```javascript
+// ❌ WRONG — never log API keys or passphrases
+log.log(`API keys: ${config.apikey}, ${config.apisecret}`);
+
+// ✅ CORRECT
+log.log(`Using exchange: ${config.exchangeName}`);
+```
+
+---
+
+## Refactoring Guidance
+
+### Codebase Maturity
+
+This is a **mixed maturity codebase**:
+
+**Modern patterns** (refactored):
+
+- JSDoc type annotations (`@typedef`, `@param`, `@returns`)
+- Soft dependencies via `utils.softRequire()`
+- Clean error handling with module name and param details
+- Dynamic exchange loading
+
+**Legacy patterns** (pre-refactor):
+
+- Procedural code with loose coupling
+- Implicit dependencies / global state assumptions
+- Minimal type hints
+- Inconsistent error handling
+
+### Refactoring Rules
+
+**Bring all code toward modern patterns incrementally:**
+
+1. **Add JSDoc** type annotations when touching old code
+2. **Extract soft dependencies** — replace module-level `require()` with in-method loading
+3. **Add parameter validation** and informative error messages
+4. **Use `utils.softRequire()`** for optional feature modules
+5. **Enhance log messages** with context (module name, function, parameters)
+
+**Don't** do large refactors in one PR — each touch should incrementally improve consistency.
+
+### When Adding New Features
+
+- Use the iteration loop pattern
+- Add a `tradeParams` flag for enabling/disabling
+- Register as a `botFeature` in `commandTxs.js` if user-controllable
+- Add a unique order purpose if the feature places orders
+- Follow the error handling pattern with module name context
+- Clear cache after any order modifications
+- Support perpetual mode if applicable (check `config.perpetual`)
+
+---
+
+## Quick Reference
+
+### Key Files
+
+| File | Purpose |
+| ------ | --------- |
+| `app.js` | Bootstrap entry point |
+| `modules/configReader.js` | Config loader (immutable) |
+| `modules/DB.js` | Database setup |
+| `modules/commandTxs.js` | Command parser, features |
+| `trade/orderUtils.js` | Order placement, caching, balance checks |
+| `trade/orderCollector.js` | Order cancellation/cleanup |
+| `trade/orderStats.js` | Statistics aggregation |
+| `helpers/fillsEngine.js` | Fill verification, VWAP |
+| `helpers/const.js` | Constants |
+| `helpers/utils.js` | Utilities |
+| `helpers/log.js` | Logging |
+| `helpers/notify.js` | Multi-channel notifications |
+| `helpers/dbModel.js` | DB ORM wrapper |
+| `trade/settings/tradeParams_Default.js` | Trade params template |
+
+### Important Constants
+
+```javascript
+constants.HOUR   = 3_600_000   // 60 * 60 * 1000
+constants.MINUTE = 60_000      // 60 * 1000
+constants.DAY    = 86_400_000  // 24 * 60 * 60 * 1000
+constants.REST_DATA_CACHE_MS = 1000  // Cache duration for REST data
+constants.MM_POLICIES = ['optimal', 'spread', 'orderbook', 'depth', 'wash']
+```
+
+### Feature Flags
+
+```javascript
+tradeParams.mm_isActive                  // Master kill switch
+tradeParams.mm_isTraderActive            // Volume maker
+tradeParams.mm_isOrderBookActive         // Order book builder
+tradeParams.mm_isLiquidityActive         // Liquidity provider
+tradeParams.mm_isPriceWatcherActive      // Price watcher
+tradeParams.mm_isPriceMakerActive        // Price maker
+tradeParams.mm_isCleanerActive           // Cleaner
+tradeParams.mm_isAntigapActive           // Anti-gap
+tradeParams.mm_isLadderActive            // Ladder
+tradeParams.mm_isSpreadMaintainerActive  // Spread maintainer
+tradeParams.mm_isQuoteHunterActive       // Quote hunter
+tradeParams.mm_isBalanceEqualizerActive  // Balance equalizer
+tradeParams.mm_isBalanceWatcherActive    // Balance watcher
+tradeParams.mm_isVolatilityActive        // Volatility chart
+tradeParams.mm_isVolumeVolatilityActive  // Volume volatility
+tradeParams.mm_isOrderNotifierActive     // Order notifier
+tradeParams.mm_isFundBalancerActive      // Fund balancer (2-key)
+t_isTwapActive                           // TWAP (independent of mm_isActive)
+```
+
+### Order Purposes
+
+`t` (trader), `ob` (orderbook), `obs` (orderbook spread), `liq` (liquidity), `sm` (spread), `ag` (antigap), `cl` (cleaner), `pw` (price watcher), `pm` (price maker), `qh` (quote hunter), `ld` (ladder), `tw` (twap), `be` (balance equalizer), `fs` (fund supplier), `tb` (trade bot), `man` (manual)
+
+---
+
+## Communication
+
+- Developers communicate with AI in **any language**
+- ALL code, documentation, comments, commit messages **MUST be in English**
+- Use clear, descriptive variable/function names
+- Add comments for non-obvious logic

--- a/.github/ai-agent-instructions.md
+++ b/.github/ai-agent-instructions.md
@@ -1,1167 +1,402 @@
-# AI Agent Instructions for ADAMANT Market-Making Bot
+# AI Agent Instructions for ADAMANT Tradebot OSS
 
-**Target Audience**: AI Coding Assistants (GitHub Copilot, Claude, Cursor, Windsurf, etc.)
+**Target audience**: AI coding assistants working inside this repository.
 
-**Language Policy**: Developers communicate with AI in any language (English, Russian, etc.), but ALL code, documentation, comments, and commit messages MUST be in English only.
+**Language policy**: Developers may talk to the agent in any language, but code, comments, docs, and commit messages must stay in English.
 
----
+## Scope
 
-## Table of Contents
+This repository is the open-source base version of the bot.
 
-1. [Project Overview](#project-overview)
-2. [Development Priorities](#development-priorities)
-3. [Architecture Deep Dive](#architecture-deep-dive)
-4. [Critical System Patterns](#critical-system-patterns)
-5. [Reliability & Safety](#reliability--safety)
-6. [Data Flow & State Management](#data-flow--state-management)
-7. [Module Reference](#module-reference)
-8. [Development Workflow](#development-workflow)
-9. [Common Pitfalls](#common-pitfalls)
-10. [Refactoring Guidance](#refactoring-guidance)
+Do not treat it as the Premium product and do not reintroduce claims or design assumptions that are not implemented here. In particular:
 
-**Supplementary Guides:**
+- Do not describe this repo as the closed-source or full-featured version
+- Do not assume 40+ exchanges, Web UI, custom strategy sub-apps, futures or perpetual trading, or mandatory WebSocket connectors
+- Do not reference premium-only modules or workflows unless the code is present in this repository
+- Prefer the real code layout in `app.js`, `modules/`, `routes/`, and `trade/` over copied historical docs
 
-- [Exchange Connector Guide](exchange-connector-guide.md) — Step-by-step instructions for creating and testing a new exchange connector (Spot REST, WebSocket, Perpetual/Futures)
-
----
+The OSS branch should be documented as a smaller, REST-first, spot-focused bot.
 
 ## Project Overview
 
-### What Is This Bot?
+ADAMANT Tradebot is a self-hosted market-making bot for centralized crypto exchanges. In this repository it focuses on the base market-making workflow:
 
-ADAMANT Trading Bot is a **self-hosted market-making bot** for cryptocurrency exchanges. It manages orders across 40+ exchanges to:
+- placing and cancelling orders
+- generating trading volume
+- maintaining spread and liquidity
+- building an order book
+- watching and reacting to price ranges
 
-- **Create trading volume** via wash trading in spread or order book
-- **Maintain spread and liquidity** with dynamic order book depth
-- **Build dynamic order books** with high-frequency live-like updates
-- **Watch and make token prices** — prevent manipulation, set price trends
-- **Support multiple modules and trading strategies** — ladder/grid, TWAP, balance equalizer, anti-gap, quote hunter, etc.
+The current open-source version is intentionally narrower than the commercial product line. Keep new docs and code aligned with that fact.
 
-**Website**: <https://marketmaking.app/>
+## Technology Snapshot
 
-### Premium and Free Versions
+- Runtime: Node.js `>=18.18`
+- Package manager: npm `>=9.0.1`
+- Language: JavaScript, CommonJS modules
+- Database: MongoDB
+- API server: Express for debug and health routes
+- Typing style: JSDoc with `.d.js` files under `types/`
 
-1. **Premium Version** (this repository): Full-featured, closed-source
-2. **Free Version**: <https://github.com/Adamant-im/adamant-tradebot> — Limited features, open-source
+## What Actually Starts
 
-**Custom Builds**: Clients (token issuers, crypto projects) order customized versions with specific premium features. Developers assemble a custom bot and push it to a separate repository. Keep code **modular** to facilitate building custom bots — every feature should be independently extractable.
+The real bootstrap flow is in `app.js`.
 
-### Technology Stack
+### Startup sequence
 
-- **Runtime**: Node.js >=20.19
-- **Database**: MongoDB 7 (with migrations)
-- **Language**: JavaScript (CommonJS modules, ES2021)
-- **Types**: JSDoc `@typedef` in `.d.js` files (not TypeScript `.d.ts`), for IDE support
-- **Communication**: ADAMANT Messenger, Telegram, Web UI, CLI
-- **Exchange APIs**: 40+ custom adapters (`trader_*.js`)
-- **Architecture**: Event-driven, single-threaded iteration loops
+1. Load config through `modules/configReader.js`
+2. Initialize database through `modules/DB.js`
+3. If ADAMANT credentials are configured, initialize the socket command pipeline through `modules/api.js` and `modules/incomingTxsParser.js`
+4. If `config.api.port` is set, start the Express API from `routes/init.js`
+5. Start the active trade modules:
+   - `trade/mm_trader.js`
+   - `trade/mm_orderbook_builder.js`
+   - `trade/mm_liquidity_provider.js`
+   - `trade/mm_price_watcher.js`
+6. In dev mode, also run `trade/tests/manual.test.js`
 
----
+Do not document startup services that are not actually initialized by this branch.
+
+## Architecture Map
+
+```text
+app.js
+├── modules/configReader.js
+├── modules/DB.js
+├── modules/api.js + modules/incomingTxsParser.js   # ADAMANT command intake when configured
+├── routes/init.js                                  # health/debug HTTP routes
+└── trade/
+    ├── mm_trader.js
+    ├── mm_orderbook_builder.js
+    ├── mm_liquidity_provider.js
+    ├── mm_price_watcher.js
+    ├── orderCollector.js
+    ├── orderStats.js
+    ├── orderUtils.js
+    ├── trader_*.js
+    ├── api/*_api.js
+    └── settings/tradeParams_*.js
+```
 
 ## Development Priorities
 
-These priorities guide ALL development decisions. When conflicts arise, higher priority wins.
+When making changes, use these priorities in order.
 
-### 1. Reliability (Critical)
+### 1. Reliability
 
-**The bot must never crash. The system must be resilient to failures.**
+The bot must keep running even when an exchange or a helper call misbehaves.
 
-- **API connectors are robust** — they distinguish between requests that failed to reach the exchange, requests that returned an error, and successful responses
-- Always wrap exchange API calls in try-catch
-- **Graceful degradation** — if one module fails, others continue working
-- **No unhandled promise rejections** — every async operation has error handling
-- **Iteration loop protection** — `isPreviousIterationFinished` prevents race conditions
-- Retry failed requests with exponential backoff where appropriate
+- Wrap exchange calls in defensive error handling
+- Prefer returning `undefined` over fabricated data when request processing fails
+- Do not introduce unhandled promise rejections
+- Preserve iteration-loop guards such as `isPreviousIterationFinished`
 
-### 2. Data Consistency (Critical)
+### 2. Exchange State Consistency
 
-**Local order/balance data must match exchange state.**
+Local state must track exchange state closely enough to keep orders safe.
 
-- **Database as source of truth** — NEVER place orders without immediate DB save
-- **Regular Cache invalidation** — call `orderUtils.clearCache()`
-- **Regular reconciliation** between local DB and exchange open orders
-- **Balance validation** — always check via `orderUtils.isEnoughCoins()` before placing orders
-- **False-empty-list protection** — detect when exchanges falsely return 0 orders, trigger emergency stop if needed
-- No duplicate orders — verify order doesn't exist before placing
+- Save placed orders immediately to the database
+- Clear cached balances and orders after order mutations
+- Do not silently convert bad API responses into empty arrays or empty objects
+- Prefer explicit status normalization over permissive fallbacks
 
-### 3. Safety (Critical)
+### 3. Trading Safety
 
-**The bot must not create unintended trading situations.**
+The bot should avoid placing orders with wrong price, amount, or balance assumptions.
 
-- **Amount/price validation** — always validate positive numbers before exchange calls
-- Respect exchange min/max limits for price and amount
-- Use correct decimals from `coin1Decimals` / `coin2DecimalsForStable`
-- **Balance protection** — never place orders exceeding available balance
-- **Rate limiting** — respect exchange API rate limits to avoid bans
+- Always use market metadata for decimals and minimums
+- Validate positive numeric inputs before exchange calls
+- Respect exchange limits when they are known
+- Do not exceed available balances
 
-### 4. Correctness (Important)
+### 4. Minimalism
 
-**Logic works according to documentation and expectations.**
+The OSS branch should stay small and understandable.
 
-- Validate all inputs (prices, amounts, pairs) before processing
-- Check feature flags (`tradeParams.mm_is*Active`) before executing logic
-- Never hardcode exchange names — use `config.exchange` dynamically
-- Handle perpetual vs spot — check `config.perpetual` flag
-- Use proper log levels: `.log()` for info, `.warn()` for recoverable issues, `.error()` for failures
+- Prefer the smallest useful interface
+- Do not add premium abstractions preemptively
+- Do not add socket or perpetual scaffolding to a basic connector
 
-### 5. Observability (Important)
+## Critical Code Patterns
 
-**Easy to understand what the bot is doing at any moment.**
+### Dynamic loading by exchange
 
-- **Comprehensive logging** — include module name, function name, and key parameters in all logs
-- **Structured error format**: `Error in functionName(${params}) of ${moduleName} module: ${error}`
-- **User notifications** — use `notify()` for important events (respects `silent_mode`)
-- **Fill statistics** — track order fills, volumes, VWAP in DB via `fillsEngine`
-- **Debug capabilities** — CLI mode for inspection without live trading
-
-### 6. Maintainability (Desirable)
-
-**Code is easy to read, change, and extend.**
-
-- **Incremental refactoring** — improve code quality with each touch (add JSDoc, extract soft dependencies, enhance error messages)
-- Follow existing patterns — match the style of surrounding code
-- **Soft dependencies** — use `utils.softRequire()` for optional modules
-- **Configuration-driven** — prefer config parameters over hardcoded behavior
-- Clear module boundaries — keep concerns separated
-
-### 7. Modularity & Exchange Agnosticism (Desirable)
-
-**Code works universally for all 40+ exchanges and is easy to extract into custom builds.**
-
-- Keep code **modular** to facilitate building custom bots easier — every feature should be independently extractable
-- Dynamic loading via `config.exchange` — never hardcode exchange names except in `trader_*.js` adapters
-- Exchange-specific quirks are abstracted inside trader adapters
-- All trader adapters expose the same interface with the same method signatures
-- Features are independently toggleable via `tradeParams` flags
-- Modules use cross-module communication via in-method `require()`, not module-level imports
-
-### Priority Trade-offs
-
-| Conflict | Resolution |
-| ---------- | ---------- |
-| **Reliability vs Speed** | Choose reliability — better to be slow than crash |
-| **Safety vs Features** | Choose safety — better to miss an opportunity than create a loss |
-| **Consistency vs Performance** | Choose consistency — cache carefully, invalidate aggressively |
-| **Correctness vs Convenience** | Choose correctness — validate thoroughly even if verbose |
-
----
-
-## Architecture Deep Dive
-
-### System Architecture
-
-```text
-┌──────────────────────────────────────────────────────────────┐
-│                   ADAMANT Trading Bot                         │
-├──────────────────────────────────────────────────────────────┤
-│                                                               │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
-│  │  ADAMANT API │  │  Telegram    │  │  Web UI /    │       │
-│  │  (Commands)  │  │  (Commands)  │  │  CLI         │       │
-│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘       │
-│         └─────────────────┴─────────────────┘                │
-│                           │                                   │
-│                    ┌──────▼───────┐                           │
-│                    │  commandTxs  │ (Command Parser)          │
-│                    └──────┬───────┘                           │
-│                           │                                   │
-│         ┌─────────────────┼─────────────────┐                │
-│    ┌────▼─────┐           │          ┌──────▼──────┐         │
-│    │ Config   │           │          │ TradeParams │         │
-│    │ (JSONC)  │           │          │  (Dynamic)  │         │
-│    │ Immutable│           │          │  Runtime    │         │
-│    └──────────┘           │          └─────────────┘         │
-│                           │                                   │
-│  ┌────────────────────────▼─────────────────────────────┐    │
-│  │              Trade Modules (mm_*.js)                  │    │
-│  │ trader | liquidity | spread | orderbook | price_..   │    │
-│  │ antigap | cleaner | ladder | twap | quote_hunter     │    │
-│  │ fund_balancer | fund_supplier | balance_equalizer    │    │
-│  │ volatility_chart | volume_volatility | notifier      │    │
-│  └───────────┬──────────────────────────────────────────┘    │
-│              │                                                │
-│    ┌─────────▼─────────┐     ┌───────────────┐              │
-│    │  orderCollector   │◄────┤  orderUtils   │              │
-│    │  (Cancel/Cleanup) │     │  (Place/Cache)│              │
-│    └─────────┬─────────┘     └───────┬───────┘              │
-│              │                       │                       │
-│    ┌─────────▼───────────────────────▼───────────┐          │
-│    │      Exchange API Adapters (trader_*.js)     │          │
-│    │      + perpetualApi (for futures)            │          │
-│    │      + WebSocket streams (real-time data)    │          │
-│    └───────────────────┬─────────────────────────┘          │
-│                        │                                     │
-│    ┌───────────────────▼─────────────────────────┐          │
-│    │            MongoDB (DB.js)                    │          │
-│    │  ordersDb | fillsDb | filledStatsDb          │          │
-│    │  balancesHistory | systemDb                   │          │
-│    └──────────────────────────────────────────────┘          │
-└──────────────────────────────────────────────────────────────┘
-```
-
-### Bootstrap Sequence (`app.js`)
-
-```text
-1. DB connects + runs migrations (modules/dbMigrations.js)
-   ↓
-2. ~1 second delay: Create tradeParams_{exchange}.js from template if missing
-   ↓
-3. ~5 seconds delay: Initialize services
-   - ADAMANT API socket (if passphrase provided)
-   - Health/Debug API (if api.port configured)
-   - Telegram bot (if manageTelegramBotToken set)
-   - Web UI API (if webui configured)
-   - Custom Strategy UI (if cs.ui.enabled)
-   - Comserver (if com_server enabled) — inter-bot communication
-   ↓
-4. Check inactivity period (heartbeat file)
-   - If offline too long → emergency pause (safety measure)
-   ↓
-5. Start ALL market-making modules via require('./trade/mm_*').run()
-   - Each module begins its own iteration loop
-   ↓
-6. Send startup notification
-```
-
-### Core Subsystems
-
-#### 1. Trade Modules (`trade/mm_*.js`)
-
-Independent market-making features and strategies. Most runs on its own iteration loop with randomized intervals. Most modules check `tradeParams.mm_isActive` as a global kill switch before doing work.
-
-#### 2. Exchange Abstraction (`trade/trader_*.js`)
-
-Factory functions that return a uniform API object. All adapters expose the same methods (see [Exchange Adapter Interface](#exchange-adapter-interface)). Loaded dynamically via:
+Exchange-specific modules are loaded dynamically. Do not hardcode exchange names outside exchange-specific files.
 
 ```javascript
 const TraderApi = require('./trader_' + config.exchange);
-const traderapi = TraderApi(config.apikey, config.apisecret, config.apipassword, log, ...);
+const traderapi = TraderApi(
+  config.apikey,
+  config.apisecret,
+  config.apipassword,
+  log,
+  undefined,
+  undefined,
+  config.exchange_socket,
+  config.exchange_socket_pull,
+);
 ```
 
-#### 3. Order Lifecycle Engine
+### Iteration loops
 
-- **orderUtils.js** — Order placement, balance checks, caching (open orders, order book, balances)
-- **orderCollector.js** — Centralized order cancellation and cleanup
-- **orderStats.js** — Statistics aggregation via MongoDB pipelines
-
-#### 4. Fills Processing (`helpers/fillsEngine.js`)
-
-Cumulative fill tracking engine with verification. Two DB collections:
-
-- `fillsDb` — event log of individual fills (produced by `orderUtils.updateOrders()`)
-- `filledStatsDb` — persistent accumulation of verified fills with VWAP calculation (survives restarts)
-
-#### 5. Configuration System
-
-- **`config.*.jsonc`** (immutable) — exchange-specific configs loaded once at startup
-- **`tradeParams_*.js`** (dynamic) — runtime-adjustable settings, modified by user commands
-
-#### 6. Command System (`modules/commandTxs.js`)
-
-Processes commands from ADAMANT Messenger, Telegram, CLI, and Web UI. Supports 39+ commands, feature enable/disable, emergency stop, confirmation mechanism.
-
----
-
-## Critical System Patterns
-
-### 1. Iteration Loop Pattern
-
-**Most trade modules follow this exact pattern:**
+Trade modules use timed loops with overlap protection.
 
 ```javascript
-const moduleName = 'mm_moduleName';
 let isPreviousIterationFinished = true;
 
-module.exports = {
-  run() {
-    this.iteration();
-  },
+async function iteration() {
+  if (isPreviousIterationFinished) {
+    isPreviousIterationFinished = false;
 
-  async iteration() {
-    const interval = setPause(); // Randomized milliseconds
-
-    if (isPreviousIterationFinished) {
-      isPreviousIterationFinished = false;
-      try {
-        await this.doWork();
-      } catch (e) {
-        log.error(`Error in ${moduleName} iteration: ${e}`);
-      } finally {
-        isPreviousIterationFinished = true;
-      }
-    } else {
-      log.warn(`${moduleName}: Postponing iteration. Previous still in progress.`);
+    try {
+      await doWork();
+    } catch (error) {
+      log.error(`Iteration failed: ${error}`);
+    } finally {
+      isPreviousIterationFinished = true;
     }
-
-    setTimeout(() => this.iteration(), interval);
-  },
-
-  async doWork() {
-    // Check master switch
-    if (!tradeParams.mm_isActive) return;
-    // Check module-specific switch
-    if (!tradeParams.mm_isModuleActive) return;
-    // Module logic...
   }
+
+  setTimeout(iteration, setPause());
+}
+```
+
+Do not remove these guards during refactors.
+
+### Two-stage adapter error handling
+
+In `trade/trader_*.js`, keep request execution and payload normalization in separate `try/catch` blocks.
+
+```javascript
+async function getBalances(nonzero = true) {
+  let balances;
+
+  try {
+    balances = await exchangeApiClient.getBalances();
+  } catch (error) {
+    log.warn(`API request getBalances() failed. ${error}`);
+    return undefined;
+  }
+
+  try {
+    return balances
+      .map((asset) => ({
+        code: asset.code,
+        free: +asset.free,
+        freezed: +asset.freezed,
+        total: +asset.total,
+      }))
+      .filter((asset) => !nonzero || asset.free || asset.freezed);
+  } catch (error) {
+    log.warn(`Error while processing getBalances() response: ${error}`);
+    return undefined;
+  }
+}
+```
+
+### Shared markets and currencies cache
+
+Current adapters commonly cache metadata on `module.exports`.
+
+```javascript
+module.exports.exchangeMarkets = {};
+module.exports.exchangeCurrencies = {};
+module.exports.gettingMarkets = false;
+module.exports.gettingCurrencies = false;
+```
+
+Preserve this pattern unless you are intentionally refactoring all call sites that depend on it.
+
+## Exchange Connector Expectations in OSS
+
+This branch is centered on basic spot REST connectors.
+
+### Baseline assumptions
+
+- Spot only
+- REST first
+- No mandatory WebSocket support
+- No perpetual or futures support
+- No requirement to implement every advanced account or funding method on day one
+
+### Baseline adapter surface
+
+For new or refreshed connectors, prefer this minimal surface first:
+
+- `features()`
+- `getMarkets()`
+- `marketInfo()`
+- `getBalances()`
+- `getOpenOrders()`
+- `getOrderDetails()`
+- `placeOrder()`
+- `cancelOrder()`
+- `cancelAllOrders()`
+- `getRates()`
+- `getOrderBook()`
+- `getTradesHistory()`
+
+Optional methods may be added later when the exchange API and OSS command surface need them:
+
+- `getCurrencies()` and `currencyInfo()`
+- `getDepositAddress()`
+- `getFees()`
+- `withdraw()`
+- fund history and transfer helpers
+
+The full factory signature should still stay compatible with existing call sites even if some arguments are unused by a REST-only connector:
+
+```javascript
+module.exports = (
+  apiKey,
+  secretKey,
+  pwd,
+  log,
+  publicOnly = false,
+  loadMarket = true,
+  useSocket = false,
+  useSocketPull = false,
+  accountNo = 0,
+  coin1 = config.coin1,
+  coin2 = config.coin2,
+) => {
+  // REST-only connector may ignore socket-related arguments
 };
 ```
 
-**Critical rules:**
+## `features()` Flags That Matter Here
 
-- `isPreviousIterationFinished` prevents overlapping executions (race conditions)
-- Randomized intervals (`setPause()`) avoid predictable API patterns
-- Single-threaded by design — no parallelism within a module
-- When disabled, iteration still runs (every ~3s) checking if reactivated
+Keep `features()` focused on fields the OSS code actually checks.
 
-### 2. Module Loading & Dynamic Dependencies
+Commonly relevant flags:
 
-Exchange-specific settings and APIs are loaded dynamically. **Never hardcode exchange names.**
+- `getMarkets`
+- `getCurrencies`
+- `placeMarketOrder`
+- `allowAmountForMarketBuy`
+- `amountForMarketOrderNecessary`
+- `getDepositAddress`
+- `createDepositAddressWithWebsiteOnly`
+- `supportCoinNetworks`
+- `supportCoinNetworksRestricted`
+- `getTradingFees`
+- `getAccountTradeVolume`
+- `getFundHistory`
+- `getFundHistoryImplemented`
+- `supportTransferBetweenAccounts`
+- `accountTypes`
+- `tradingAccountType`
+- `orderNumberLimit`
+- `selfTradeProhibited`
+- `apiProcessingDelayMs`
 
-```javascript
-// ✅ CORRECT: Dynamic loading
-const tradeParams = require('./settings/tradeParams_' + config.exchange);
-const TraderApi = require('./trader_' + config.exchange);
-const traderapi = TraderApi(config.apikey, config.apisecret, ...);
-
-// ❌ WRONG: Hardcoded exchange
-const traderapi = require('./trader_binance')(apikey, apisecret);
-```
-
-### 3. Cross-Module Communication
-
-**Regularly modules load other modules INSIDE methods, not at module level.** This prevents circular requires and allows feature toggling:
-
-```javascript
-// ✅ CORRECT: Load inside method (soft dependency)
-async function updateOrderBook() {
-  if (tradeParams.mm_isLiquidityActive) {
-    const lp = require('./mm_liquidity_provider');
-    await lp.updateLiquidityAfterPriceChange(side, callerName);
-  }
-}
-
-// ❌ WRONG: Load at module level (hard dependency)
-const lp = require('./mm_liquidity_provider');
-```
-
-For truly optional modules, use `utils.softRequire()`:
+For the OSS baseline, WebSocket-related flags should default to disabled unless the code is really implemented:
 
 ```javascript
-const vv = utils.softRequire('./mm_volume_volatility');
-if (vv && tradeParams.mm_isVolumeVolatilityActive) {
-  const coefficient = vv.getVolumeVolatilityCoefficient();
-}
-```
-
-### 4. Two-Account (2-Key) Trading
-
-Some modules support a second exchange account (`config.apikey2` / `config.apisecret2`) to avoid self-trade restrictions:
-
-```javascript
-const TraderApi = require('./trader_' + config.exchange);
-const traderapi = TraderApi(config.apikey, config.apisecret, ...);
-
-let traderapi2;
-if (config.apikey2) {
-  traderapi2 = TraderApi(config.apikey2, config.apisecret2, ..., /* accountNo */ 2, ...);
-  traderapi2.isSecondAccount = true;
-}
-
-const useSecondAccount = traderapi2 && !isPerpetual;
-// Account 1 places maker order, Account 2 takes it
-const makerApi = traderapi;
-const takerApi = useSecondAccount ? traderapi2 : traderapi;
-```
-
-Modules with 2-account support: mm_trader, mm_price_maker, mm_quote_hunter, mm_twap, mm_cleaner, mm_fund_balancer.
-
-### 5. Config vs TradeParams
-
-| Aspect | `config` (configReader.js) | `tradeParams` |
-| -------- | --------------------------- | --------------- |
-| Source | `config.*.jsonc` | `tradeParams_{exchange}.js` |
-| Mutability | **Immutable** after load | **Dynamic** — modified at runtime |
-| Contains | API keys, exchange, pair, services | Feature flags, amounts, intervals, strategies |
-| Modified by | Only on restart | User commands (`/enable`, `/params`), saved to file |
-| Access | `require('./modules/configReader')` | `require('./settings/tradeParams_' + config.exchange)` |
-
-**Important derived config properties:**
-
-- `config.exchange` — lowercase exchange name
-- `config.exchangeName` — original case exchange name
-- `config.defaultPair` — `config.perpetual || config.pair`
-- `config.coin1`, `config.coin2` — pair components
-- `config.dev` — development mode flag
-- `config.hasAdmPassphrase` — whether ADAMANT passphrase is configured
-- `config.bot_id` — unique bot identifier (`pair@exchange-account`)
-
-### 6. Features vs Order Purposes
-
-**Features** (`botFeatures` in `commandTxs.js`) are user-controllable capabilities. **Order Purposes** are internal order type identifiers stored in `ordersDb`. They are NOT 1:1.
-
-Some features create orders with a specific purpose. Some features DON'T have their own purpose — they modify behavior of other modules or set parameters.
-
-| Feature | tradeParam | Purpose | Description |
-| -------- | ----------- | --------- | ------------- |
-| `t` | `mm_isTraderActive` | `t` | Making trading volume |
-| `ob` | `mm_isOrderBookActive` | `ob`, `obs` | Dynamic order book building |
-| `liq` | `mm_isLiquidityActive` | `liq` | Liquidity and spread maintenance |
-| `sm` | `mm_isSpreadMaintainerActive` | `sm` | Spread maintainer |
-| `ag` | `mm_isAntigapActive` | `ag` | Order book anti-gap |
-| `cl` | `mm_isCleanerActive` | `cl` | Order book cleaner |
-| `pw` | `mm_isPriceWatcherActive` | `pw` | Price watching |
-| `ld` | `mm_isLadderActive` | `ld` | Ladder/grid trading |
-| `qh` | `mm_isQuoteHunterActive` | `qh` | Quote hunter |
-| `tw` | `t_isTwapActive` | `tw` | TWAP orders |
-| `be` | `mm_isBalanceEqualizerActive` | `be` | Balance equalizer |
-| `on` | `mm_isOrderNotifierActive` | — | Order notifier (monitoring only) |
-| `bw` | `mm_isBalanceWatcherActive` | — | Balance watching (monitoring only) |
-| `vc` | `mm_isVolatilityActive` | — | Volatility chart (modifies `t` behavior) |
-| `vv` | `mm_isVolumeVolatilityActive` | — | Volume volatility (modifies `t` behavior) |
-| `sp` | `mm_priceSupportLowPrice` | — | Support price (sets param to 0) |
-| `pmv` | `mm_isPriceChangeVolumeActive` | — | PM/PW additional volume |
-| `fb` | `mm_isFundBalancerActive` | — | Fund balancer (adjusts `mm_buyPercent`) |
-
-Additional order purposes (not direct features): `fs` (fund supplier), `pm` (price maker), `tb` (trade bot manual), `man` (manual).
-
-Each feature has a `requires` field for dependencies (e.g., `'vc'` requires `mm_isTraderActive`).
-
-Query orders by purpose:
-
-```javascript
-const smOrders = await ordersDb.find({
-  isProcessed: false,
-  purpose: 'sm',
-  pair: config.pair,
-  exchange: config.exchange
-});
-```
-
-### 7. Order Placement Flow
-
-Every order placement must follow this sequence:
-
-```javascript
-// 1. Parse market for decimals
-const { coin1Decimals, coin2DecimalsForStable } = orderUtils.parseMarket(pair);
-
-// 2. Calculate amount and price
-const amount = baseAmount.toFixed(coin1Decimals);
-const price = quotePrice.toFixed(coin2DecimalsForStable);
-
-// 3. Validate balance
-const balanceCheck = await orderUtils.isEnoughCoins(
-  side, formattedPair, baseAmount, quoteAmount, purpose, '', moduleName, api
-);
-if (!balanceCheck.result) {
-  log.warn(`${moduleName}: ${balanceCheck.message}`);
-  return;
-}
-
-// 4. Place order on exchange
-const result = await traderapi.placeOrder(side, pair, price, amount, 1);
-if (!result?.orderId) {
-  log.warn(`${moduleName}: Failed to place ${side} order`);
-  return;
-}
-
-// 5. Save to DB IMMEDIATELY
-const order = new db.ordersDb({
-  _id: result.orderId,
-  side, pair, price: +price,
-  coin1Amount: +amount, coin2Amount: quoteAmount,
-  purpose, exchange: config.exchange, date: Date.now(),
-  isProcessed: false
-}, true); // true = save immediately
-
-// 6. Clear cache
-orderUtils.clearCache(`${moduleName}/functionName`);
-
-// 7. Log success
-log.info(`${moduleName}: Placed ${side} order for ${amount} ${coin1} at ${price} ${coin2}`);
-```
-
-### 8. Order Cancellation
-
-**Always use `orderCollector.clearOrderById()` — it handles DB update, cache invalidation, and logging:**
-
-```javascript
-// ✅ CORRECT
-const result = await orderCollector.clearOrderById(
-  orderId, pair, side, `${moduleName}/reason`, reasonDescription, reasonObj, api
-);
-
-// ❌ WRONG — missing DB update, cache invalidation, logging
-await traderapi.cancelOrder(orderId, side, pair);
-```
-
-### 9. Caching Pattern
-
-Three caches in `orderUtils` for the primary account only:
-
-```javascript
-// Cache duration: constants.REST_DATA_CACHE_MS (1000ms)
-orderUtils.getOpenOrdersCached(pair, moduleName)    // Open orders
-orderUtils.getOrderBookCached(pair, moduleName)     // Order book
-orderUtils.getBalancesCached(nonzero, moduleName)   // Balances
-```
-
-- Socket data bypasses cache when available
-- Second account / perpetual API always makes fresh requests
-- **Always clear cache after modifying orders**: `orderUtils.clearCache(callerName)`
-
-### 10. Error Handling Pattern
-
-```javascript
-async function someFunction(param1, param2) {
-  const paramString = `param1: ${param1}, param2: ${param2}`;
-
-  try {
-    const result = await traderapi.someMethod(param1, param2);
-
-    if (!result || !result.success) {
-      log.warn(`${moduleName}: Failed someMethod(${paramString})`);
-      notify(`Failed operation`, 'warn', config.silent_mode);
-      return;
-    }
-
-    log.info(`${moduleName}: Successfully executed someMethod(${paramString})`);
-
-  } catch (e) {
-    log.error(`Error in someFunction(${paramString}) of ${moduleName} module: ${e}`);
-    notify(`Error in ${moduleName}`, 'error', config.silent_mode);
-  }
+features() {
+  return {
+    getMarkets: true,
+    getCurrencies: false,
+    placeMarketOrder: false,
+    allowAmountForMarketBuy: false,
+    amountForMarketOrderNecessary: false,
+    getDepositAddress: false,
+    createDepositAddressWithWebsiteOnly: false,
+    supportCoinNetworks: false,
+    supportCoinNetworksRestricted: false,
+    getTradingFees: false,
+    getAccountTradeVolume: false,
+    getFundHistory: false,
+    getFundHistoryImplemented: false,
+    supportTransferBetweenAccounts: false,
+    accountTypes: false,
+    tradingAccountType: 'trade',
+    orderNumberLimit: undefined,
+    selfTradeProhibited: false,
+    apiProcessingDelayMs: undefined,
+    socketSupport: false,
+    socketPullSupport: false,
+    socketEnabled: false,
+  };
 }
 ```
 
----
-
-## Reliability & Safety
-
-### Exchange API Error Handling in Adapters
-
-Each `trader_*.js` adapter has a `handleResponse()` function that classifies HTTP responses:
-
-- **5xx, 429** — Temporary errors → reject → retry
-- **401, 403** — Authentication errors → log error, check API keys
-- **400** — Bad params → resolve with error data for caller to handle
-- **200** — Success → process data
-
-### False-Empty-List Protection
-
-`orderUtils.updateOrders()` includes a safety heuristic:
-
-1. If exchange returns 0 open orders but DB has many unprocessed orders → suspicious
-2. Verifies via `getOrderDetails()` API if available
-3. If confirmed suspicious → triggers `emergencyStop()` to pause all trading
-4. Prevents accidentally marking all orders as filled when exchange API glitches
-
-### Emergency Stop
-
-`commandTxs.commands.emergencyStop(callerName, details)`:
-
-- Sets `mm_isActive = false`
-- Saves config immediately
-- Sends **priority notification** via all channels
-- Called by:
-  - User command (`/emergency_stop`)
-  - `orderUtils.updateOrders()` on suspicious API behavior
-  - Bootstrap `checkInactivityPeriod()` if bot was offline too long
-
-### Inactivity Protection
-
-On startup, the bot checks a heartbeat file (`logs/heartbeat`):
-
-- Written every 60 seconds during normal operation
-- If the gap between last heartbeat and now exceeds `config.pauseAfterInactivity` (default: 6h):
-  - Bot starts in **paused state** (emergency stop)
-  - Prevents unexpected behavior after extended downtime
-  - Operator must manually review and `/start`
-
----
-
-## Data Flow & State Management
-
-### Order State Lifecycle
-
-Orders have these status flags:
-
-| Field | When True |
-| ------- | ----------- |
-| `isProcessed` | Filled, cancelled, or disappeared from exchange |
-| `isExecuted` | Filled or partly filled (has executed amount) |
-| `isClosed` | Same as isProcessed — order is no longer active |
-| `isCancelled` | Bot explicitly cancelled it |
-| `isExpired` | Order lifetime exceeded |
-| `isNotFound` | Missing from exchange's open orders list |
-
-**Lifecycle:**
-
-1. **Placed** → `{ isProcessed: false, isExecuted: false }`
-2. **Partially filled** → `{ isProcessed: false, isExecuted: true }`
-3. **Fully filled** → `{ isProcessed: true, isExecuted: true, isClosed: true, (isNotFound: true in exchange open orders) }`
-4. **Cancelled by bot** → `{ isProcessed: true, isCancelled: true, isClosed: true }`
-
-### Fills Processing Pipeline
-
-```text
-1. orderUtils.updateOrders() detects fills
-   → fillsEngine.addFill() builds fill data
-   → fillsEngine.addFillsDbRecord() saves to fillsDb { isProcessed: false }
-
-2. Trade modules call fillsEngine.processFills():
-   → Read unprocessed fillsDb records
-   → Verify each fill via traderapi.getOrderDetails()
-   → Confirmed fills: aggregate into filledStatsDb via MongoDB $inc
-   → Mark fillsDb records as isProcessed: true
-
-3. fillsEngine.getStats() returns VWAP metrics:
-   → VWAP per side (buy/sell)
-   → VWAP Spread
-   → Cashflow PnL, Inventory change
-   → Mark-to-Market PnL
-```
-
-### Fill Verification Policy
-
-When `fillsEngine.verifyOrderFilled()` checks a fill via exchange API:
-
-- No `getOrderDetails()` method → assume filled (can't disprove)
-- Status `filled` → confirmed
-- Status `new`/`part_filled`/`cancelled` → rejected (mistakenly marked)
-- Status `unknown` → treat as confirmed (can't disprove)
-- API failure → return `undefined` (retry later)
-
-### Balance Tracking
-
-```text
-1. orderUtils.getBalancesCached() → exchange API → cache
-2. balancesHistory.saveSnapshotIfChanged() → persist to DB
-3. mm_balance_watcher.guardBalances() → compare to reference, alert on anomalies
-```
-
----
-
-## Module Reference
-
-### Trade Modules
-
-#### Volume & Trading
-
-| Module | File | Purpose | Interval | Description |
-| -------- | ------ | --------- | ---------- | ------------- |
-| **Trader** | `mm_trader.js` | `t` | Configurable | Creates trading volume. Policies: `spread`, `orderbook`, `optimal`, `depth`, `wash`. Supports 2-account and perpetual. |
-| **TWAP** | `mm_twap.js` | `tw` | Configurable | Time-Weighted Average Price execution. Splits large order over time. **Independent from `mm_isActive`** — runs even when bot is stopped. |
-
-#### Order Book Management
-
-| Module | File | Purpose | Interval | Description |
-| -------- | ------ | --------- | ---------- | ------------- |
-| **Order Book Builder** | `mm_orderbook_builder.js` | `ob` | 2-6s | Places/removes orders for dynamic, live-like order book. Supports perpetual. |
-| **Order Book Spread** | `mm_orderbook_spread.js` | `obs` | 1-4s | Places orders ahead of detected big orders in the book. Spot only. |
-| **Liquidity Provider** | `mm_liquidity_provider.js` | `liq` | 10-20s | Places orders deeper in book. Features: spread support, safe liquidity (VWAP-based), flowing liquidity. Spot only. |
-| **Spread Maintainer** | `mm_spread_maintainer.js` | `sm` | 1-2min | Keeps bid-ask spread tight with short-lived orders (10-30min lifetime). Also called by other modules. Spot only. |
-| **Anti-gap** | `mm_antigap.js` | `ag` | 15-25s | Fills gaps in order book where price intervals exceed average. Max 50 orders. Spot only. |
-
-#### Price Management
-
-| Module | File | Purpose | Interval | Description |
-| -------- | ------ | --------- | ---------- | ------------- |
-| **Price Watcher** | `mm_price_watcher.js` | `pw` | 15-30s | Monitors price within a range from various sources. Actions: `fill` (buy/sell to restore) or `prevent` (block other modules). Validates against InfoService. |
-| **Price Maker** | `mm_price_maker.js` | — | 30s-1min | Drives price toward target. Supports 2-account. Has backstep logic for realistic charts. |
-| **Volatility Chart** | `mm_volatility_chart.js` | — | — | Sets price trends mimicking top-coin charts. Works within Price Watcher's range. Sets targets for Price Maker. |
-| **Volume Volatility** | `mm_volume_volatility.js` | — | 4-5min | Calculates volume coefficient (0.25×-4×) based on recent price changes. Adjusts mm_trader amounts. Spot only. |
-
-#### Balance & Fund Management
-
-| Module | File | Purpose | Interval | Description |
-| -------- | ------ | --------- | ---------- | ------------- |
-| **Cleaner** | `mm_cleaner.js` | `cl` | 4-9s | Anti-cheat: detects/removes small manipulation orders. Policies: `preventCheating`, `takeAll`, `minimumSpread`, `smallSpread`. Spot only. |
-| **Quote Hunter** | `mm_quote_hunter.js` | `qh` | 5-10s | Accumulates quote currency by selling base at favorable rates. 2-account support. Spot only. |
-| **Balance Equalizer** | `mm_balance_equalizer.js` | `be` | 1-3min | Keeps coin1/coin2 near-equal in USD value. Strategies: `bp` (adjust buyPercent) or `market` (place orders). Single-key only. Spot only. |
-| **Fund Balancer** | `mm_fund_balancer.js` | — | 3-7min | Adjusts `mm_buyPercent` to keep coin2 balanced across 2 accounts. 2-key only. Spot only. |
-| **Fund Supplier** | `mm_fund_supplier.js` | `fs` | 1-3min | Exchanges coins to maintain minimum balances for configured pairs. Uses `config.fund_supplier` settings. Spot only. |
-| **Ladder** | `mm_ladder.js` | `ld` | — | Grid/ladder trading. When closest order fills, places mirrored order on opposite side. Supports two independent ladder instances (`ld1`, `ld2`). Complex state machine with `LADDER_STATES`. |
-
-#### Monitoring
-
-| Module | File | Purpose | Interval | Description |
-| -------- | ------ | --------- | ---------- | ------------- |
-| **Balance Watcher** | `mm_balance_watcher.js` | — | — | Compares current balances to reference timestamp. Alerts on abnormal coin2 decrease or expected value drop. No orders. |
-| **Order Notifier** | `mm_order_notifier.js` | — | 5-15s | Monitors order book for significant third-party orders placed/removed. No orders. |
-
-### Cross-Module Call Chain
-
-Key inter-module dependencies (called inside methods, not at module level):
-
-```text
-mm_trader → mm_spread_maintainer.maintainSpreadAfterPriceChange()
-mm_price_maker → mm_spread_maintainer.maintainSpreadAfterPriceChange()
-mm_price_watcher → mm_spread_maintainer.maintainSpreadAfterPriceChange()
-mm_quote_hunter → mm_spread_maintainer.maintainSpreadAfterPriceChange()
-mm_spread_maintainer → mm_liquidity_provider.updateLiquidityAfterPriceChange()
-orderUtils.getBalancesCached() → mm_balance_watcher.guardBalances() (via softRequire)
-```
-
-### Core Modules
-
-| Module | File | Purpose |
-| -------- | ------ | --------- |
-| **configReader** | `modules/configReader.js` | Loads and validates `config.*.jsonc`. Immutable after load. Derives `config.exchange`, `config.pair`, `config.coin1/coin2`, etc. |
-| **DB** | `modules/DB.js` | MongoDB connection, collection setup with indexes, migration runner. Exports collection helpers. |
-| **commandTxs** | `modules/commandTxs.js` | Command parser for ADAMANT/Telegram/CLI/WebUI. 39+ commands, feature management, emergency stop, confirmation mechanism. |
-| **adamantApi** | `modules/adamantApi.js` | ADAMANT blockchain integration and WebSocket for receiving commands. |
-| **perpetualApi** | `modules/perpetualApi.js` | Singleton factory for perpetual/futures contract adapters. Loads from `trade/api/contract/{exchange}PerpetualApi.js`. Returns `null` if `config.perpetual` is falsy. |
-| **Store** | `modules/Store.js` | Persistent state management via `systemDb`. Tracks last processed ADM block height, generic get/set for system fields. |
-| **eventEmitter** | `modules/eventEmitter.js` | Event bus with one event: `'parameters:update'` — broadcast when config changes. |
-| **botInterchange** | `modules/botInterchange.js` | Inter-bot communication via Socket.IO. Allows bots on different exchanges/pairs to coordinate. AES-encrypted. |
-| **dbMigrations** | `modules/dbMigrations.js` | Schema migrations. Current: renames legacy `type` field to `side` in orders. Errors halt startup. |
-
-### Helper Modules
-
-| Module | File | Purpose |
-| -------- | ------ | --------- |
-| **const** | `helpers/const.js` | Time constants (MINUTE, HOUR, DAY), policy lists, regex patterns, thresholds, cache durations. |
-| **utils** | `helpers/utils.js` | ~3600 lines of utilities: `parseSmartTime()`, `parseSmartNumber()`, `softRequire()`, `watchConfig()`, `saveConfig()`, logging helpers, math, formatting. |
-| **log** | `helpers/log.js` | Logging with levels: `none < error < warn < info < log < debug < trace`. Writes to `./logs/{date}.log` with ANSI colors. Writes heartbeat file every 60s. |
-| **notify** | `helpers/notify.js` | Multi-channel notifications: ADAMANT, Telegram, Slack, Discord, Email. Supports priority channels, silent mode, email aggregation. |
-| **fillsEngine** | `helpers/fillsEngine.js` | Fill verification, VWAP calculation, PnL metrics. Cumulative stats from a reset point. |
-| **dbModel** | `helpers/dbModel.js` | Lightweight ORM wrapper. Static: `find()`, `findOne()`, `count()`, `updateOne()`, `deleteOne()`, `aggregate()`. Instance: `save()`, `update()`. |
-| **balancesHistory** | `helpers/balancesHistory.js` | Records balance snapshots to DB when changes are detected. |
-
-### Exchange Adapter Interface
-
-All `trader_*.js` files are factory functions with this signature:
-
-```javascript
-module.exports = (apiKey, secretKey, pwd, log, publicOnly, loadMarket,
-                  useSocket, useSocketPull, accountNo, coin1, coin2) => { ... }
-```
-
-**Returned object methods:**
-
-| Method | Purpose |
-| -------- | --------- |
-| `getMarkets(pair?)` | Fetch/cache trading pairs info |
-| `getCurrencies(coin?)` | Fetch/cache currency info |
-| `marketInfo(pair)` | Get cached market info for a pair |
-| `features(pair?)` | Exchange capability flags |
-| `getBalances(nonzero?, accountType?)` | Account balances |
-| `getOpenOrders(pair)` | List open orders |
-| `getOrderDetails(orderId, pair)` | Single order status |
-| `placeOrder(side, pair, price, amount, limit, coin2Amount)` | Place buy/sell order |
-| `cancelOrder(orderId, side, pair)` | Cancel one order |
-| `cancelAllOrders(pair)` | Cancel all orders for pair |
-| `getOrderBook(pair, limit)` | Order book depth |
-| `getRates(pair)` | 24h ticker/rates |
-| `getTradesHistory(pair, limit)` | Recent trades |
-| `getCandlesHistory(pair, timeframe, since, limit)` | OHLCV candles |
-| `getDepositAddress(coin)` | Deposit address |
-| `getFees(coinOrPair)` | Trading/withdrawal fees |
-| `transfer(coin, from, to, amount)` | Internal transfer |
-| `withdraw(address, amount, coin, fee, network)` | External withdrawal |
-
-**`features()` capability flags** include: `getMarkets`, `placeMarketOrder`, `selfTradeProhibited`, `orderNumberLimit`, `isDemo`, `supportTransferBetweenAccounts`, etc.
-
-### Database Collections
-
-```javascript
-const db = require('./modules/DB');
-
-db.ordersDb         // Orders: find(), findOne(), save(), updateOne(), count()
-db.fillsDb          // Fill event log
-db.filledStatsDb    // Persistent fill statistics (VWAP accumulators)
-db.balancesHistory  // Balance snapshots (raw MongoDB collection)
-db.systemDb         // System state (last block height, etc.)
-db.incomingTxsDb    // ADAMANT commands
-db.incomingTgTxsDb  // Telegram commands
-db.incomingCLITxsDb // CLI commands
-db.webTerminalMessages // Web UI messages (raw collection)
-```
-
-**DB Model methods** (from `helpers/dbModel.js`):
-
-| Method | Type | Description |
-| -------- | ------ | ------------- |
-| `Model.find(query)` | Static | Returns array of Model instances |
-| `Model.findOne(query)` | Static | Returns single Model instance or null |
-| `Model.count(query)` | Static | Returns count |
-| `Model.updateOne({ filter, update, options })` | Static | MongoDB updateOne |
-| `Model.deleteOne(query)` | Static | Deletes one document |
-| `Model.aggregate(pipeline)` | Static | MongoDB aggregation |
-| `instance.save()` | Instance | Insert or upsert (depends on `_id` presence) |
-| `instance.update(obj, shouldSave)` | Instance | Merge properties, optionally persist |
-
-### Type System
-
-Types are defined as JSDoc `@typedef` in `types/*.d.js` files (not TypeScript):
-
-- **Generic exchange types**: `orders.d.js`, `depth.d.js`, `rates.d.js`, `markets.d.js`, `assets.d.js`, `fills.d.js`, etc.
-- **Bot-internal types**: `types/bot/parsedMarket.d.js`, `types/bot/orderBookInfo.d.js`, `types/bot/orderMetrics.d.js`, etc.
-- **Exchange-specific types**: `types/binance/`, `types/bybit/`, `types/kraken/`, etc.
-- **Contract types**: `types/contracts/` — perpetual contract–specific types
-
-### Custom Strategy System (`trade/cs/`)
-
-Self-contained sub-application with its own `package.json`. Provides:
-
-- Technical-indicator-based strategies (RSI, etc.)
-- Backtesting with historical data
-- Paper trading
-- Live trading with configurable parameters
-- Separate Web UI (`cs.ui`)
-
-Managed by `trade/cs_manager.js`. Installed via `postinstall` script.
-
----
-
-## Development Workflow
-
-### Mandatory Connector Delivery Rules (AI Agents)
-
-When creating or refactoring an exchange connector, AI agents MUST follow these rules:
-
-1. Add detailed JSDoc and typedef usage from `types/*.d.js` in both API and trader connector files.
-2. Create exchange-specific endpoint response types under `types/{exchange}/` with realistic `@example` blocks.
-3. Add direct official endpoint documentation links in JSDoc for each API method.
-4. Avoid permissive fallback masking (`?.list || []`) that hides malformed responses; validate shape explicitly.
-5. Use `marketInfo()` metadata in candles normalization code.
-6. Use exchange bulk cancellation endpoint for `cancelAllOrders()` when available.
-7. Reuse helper logic from `helpers/utils.js`; if generic helper is missing, extract it there.
-8. Provide detailed test evidence (raw exchange payload + normalized output), including all `getOrderDetails` status mappings: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
-9. Save test result reports to separate files for each mode: `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-mock) ... .md` for mock runs and `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-live) ... .md` for live runs.
-10. `trade/settings/tradeParams_{exchange}.js` must be a full copied object (no re-export from `tradeParams_Default`).
-11. Keep all Markdown docs lint-clean; follow markdownlint rules (including `MD022`, `MD032`, `MD007`, `MD034`, `MD040`).
-12. Do not use ambiguous `default` typedef names in exchange-specific types; use human-readable exchange-prefixed names (for example, `DextradeSymbols`, `DextradeOrder`) and import them explicitly.
-13. In one-line parameter/property/list descriptions use no trailing period for a single sentence. If description contains two or more sentences, keep terminal periods for each sentence.
-
-### Commands
+## Files You Should Trust First
+
+When you need source-of-truth behavior, inspect these files first:
+
+- `app.js`
+- `modules/configReader.js`
+- `modules/commandTxs.js`
+- `trade/orderUtils.js`
+- `trade/orderCollector.js`
+- `trade/mm_trader.js`
+- `trade/mm_orderbook_builder.js`
+- `trade/mm_liquidity_provider.js`
+- `trade/mm_price_watcher.js`
+- one of the existing `trade/trader_*.js` files closest to the exchange you are adding
+
+## Commands
+
+Use the real npm scripts from `package.json`.
 
 ```bash
-npm start              # Production (uses config.default.jsonc or config.jsonc)
-npm run start:config -- <name>  # Run with custom config name: config.<name>.jsonc
-npm run start:dev      # Development (uses config.dev.jsonc, config.dev = true)
-npm run cli            # CLI mode (interactive commands, no ADAMANT passphrase)
-npm run cli:config -- <name>    # CLI mode with custom config name
-npm run cli:dev        # CLI mode with dev config
-npm run clear          # Clear database (drops all collections) for default config
-npm run clear:config -- <name> clear_db  # Clear database for custom config
-npm test               # Run Jest tests
-npm run lint           # ESLint check (visualstudio format)
-npm run lint:fix       # ESLint auto-fix
+npm start
+npm run start:dev
+npm run clear
+npm test
+npm run lint
+npm run lint:fix
 ```
 
-### Config File Selection
+For custom configs, the runtime also supports direct invocation through `node app.js <name>` because `modules/configReader.js` resolves `config.<name>.jsonc`.
 
-The bot selects config based on CLI argument:
+## Documentation Rules for This Repo
 
-- `npm start` → `config.default.jsonc`
-- `npm run start:config -- {name}` → `config.{name}.jsonc`
-- `npm run start:dev` → `config.dev.jsonc` (treated as dev config)
-- `node app.js {name}` → `config.{name}.jsonc` (direct launch, equivalent to `start:config`)
+- Document the OSS branch only
+- Prefer concrete statements tied to files that exist
+- If a capability is optional or exchange-specific, label it that way
+- If current adapters vary a little, say so directly instead of pretending the interface is already perfectly uniform
+- Do not add Premium marketing language to internal engineering docs
 
-### Adding a New Exchange
+## Common Mistakes to Avoid
 
-See the comprehensive **[Exchange Connector Guide](exchange-connector-guide.md)** for step-by-step instructions covering:
+### Inventing missing subsystems
 
-- Plain API client (`trade/api/{exchange}_api.js`) with `handleResponse()`, `publicRequest()`, `protectedRequest()`
-- Error descriptions file (`trade/api/{exchange}_errors.js`)
-- Trader adapter (`trade/trader_{exchange}.js`) with all required methods and return shapes
-- Config registration and exchange name setup
-- Testing each method individually (request processing, balances, orders, trades, etc.)
-- WebSocket connector (public, private, pull)
-- Perpetual/Futures connector with module compatibility matrix
-- Automated Jest tests with mock adapter
-- MM simulation testing
+Do not add docs that assume this branch has:
 
-**Quick summary:**
+- perpetual or futures APIs
+- required WebSocket layers
+- a full Web UI application
+- premium-only coordination or custom-build infrastructure
 
-1. **Create API client**: `trade/api/{exchange}_api.js` + `trade/api/{exchange}_errors.js`
-2. **Create trader adapter**: `trade/trader_{exchange}.js` — implement all methods from the [Exchange Adapter Interface](#exchange-adapter-interface)
-3. **Create config**: `config.{exchange}_test.jsonc`
-4. **Add exchange name** to the `exchanges` array in `config.default.jsonc`
-5. **(Optional)** Create exchange-specific trade params override: `trade/settings/tradeParams_{exchange}.js`
-6. **Test**: `node app.js {config_name}` — follow the testing checklist in the guide
-
-### File Structure
-
-```text
-adamant-tradebot-me/
-├── app.js                         # Bootstrap entry point
-├── config.*.jsonc                 # Exchange-specific configs (immutable)
-├── package.json
-├── api/                           # Web UI API (REST endpoints)
-├── bin/
-│   └── cli.js                     # CLI entry point
-├── helpers/
-│   ├── const.js                   # Constants (time, thresholds, policies)
-│   ├── log.js                     # Logging + heartbeat
-│   ├── notify.js                  # Multi-channel notifications
-│   ├── utils.js                   # Utilities (~3600 lines)
-│   ├── fillsEngine.js             # Fill verification, VWAP
-│   ├── dbModel.js                 # Lightweight MongoDB ORM
-│   └── balancesHistory.js         # Balance snapshots
-├── modules/
-│   ├── configReader.js            # Config loader (immutable)
-│   ├── DB.js                      # MongoDB setup + migrations
-│   ├── commandTxs.js              # Command parser + features
-│   ├── adamantApi.js              # ADAMANT blockchain integration
-│   ├── perpetualApi.js            # Perpetual contracts API factory
-│   ├── Store.js                   # Persistent system state
-│   ├── eventEmitter.js            # Event bus
-│   ├── botInterchange.js          # Inter-bot communication
-│   └── dbMigrations.js            # DB schema migrations
-├── trade/
-│   ├── mm_*.js                    # Market-making modules (18 modules)
-│   ├── trader_*.js                # Exchange API adapters (40+ exchanges)
-│   ├── orderCollector.js          # Order cancellation/cleanup
-│   ├── orderUtils.js              # Order helpers, caching, balance checks
-│   ├── orderStats.js              # Statistics aggregation
-│   ├── cs_manager.js              # Custom strategy manager
-│   ├── api/                       # Exchange-specific API clients
-│   │   ├── binance_api.js
-│   │   └── contract/              # Perpetual contract adapters
-│   └── settings/
-│       ├── tradeParams_Default.js # Template for trade parameters
-│       └── tradeParams_*.js       # Exchange-specific overrides
-├── telegramBot/                   # Telegram bot integration
-├── types/                         # JSDoc type definitions (.d.js)
-│   ├── bot/                       # Bot-internal types
-│   ├── contracts/                 # Contract-specific types
-│   ├── binance/, bybit/, ...      # Exchange-specific raw API types
-│   └── *.d.js                     # Generic exchange types
-└── .github/
-    └── ai-agent-instructions.md   # This file
-```
-
-### Code Style
-
-- ESLint with Google config + custom rules
-- Single quotes, template literals allowed
-- Max line length: 133 (excluding comments, strings, URLs)
-- Prefer arrow callbacks, object shorthand
-- `eqeqeq: 'always'` — strict equality
-- Ignored paths: `trade/settings/`, `trade/tests/`, `trade/cs/test/`
-
----
-
-## Common Pitfalls
-
-### ❌ Hardcoding Exchange Names
+### Hardcoding exchange names
 
 ```javascript
-// ❌ WRONG
+// Wrong
 const traderapi = require('./trader_binance')(...);
 
-// ✅ CORRECT
+// Correct
 const traderapi = require('./trader_' + config.exchange)(...);
 ```
 
-### ❌ Placing Orders Without DB Save
+### Returning fake-safe values
 
-```javascript
-// ❌ WRONG — no DB persistence, system loses track
-const result = await traderapi.placeOrder(side, pair, price, amount);
+Avoid patterns like `response?.list || []` when a malformed payload should instead fail loudly and return `undefined`.
 
-// ✅ CORRECT — save immediately
-const result = await traderapi.placeOrder(side, pair, price, amount);
-const order = new db.ordersDb({ _id: result.orderId, ... }, true);
-```
+### Skipping immediate order persistence
 
-### ❌ Skipping `isPreviousIterationFinished`
+If a change touches order placement flow, make sure the created order is still stored immediately and caches are invalidated.
 
-```javascript
-// ❌ WRONG — overlapping iterations cause race conditions
-async iteration() {
-  await this.doWork();
-  setTimeout(() => this.iteration(), interval);
-}
+## Connector Guide
 
-// ✅ CORRECT
-if (isPreviousIterationFinished) {
-  isPreviousIterationFinished = false;
-  await this.doWork();
-  isPreviousIterationFinished = true;
-}
-```
+Use `exchange-connector-guide.md` as the preferred guide for new OSS connectors.
 
-### ❌ Mixing Perpetual and Spot
+That guide intentionally describes the target baseline for this repository:
 
-```javascript
-// ❌ WRONG — always using spot API
-const traderapi = require('./trader_' + config.exchange)(...);
+- plain REST API client
+- spot trader adapter
+- minimal method surface first
+- optional extensions later
 
-// ✅ CORRECT — check config.perpetual
-const isPerpetual = Boolean(config.perpetual);
-const traderapi = isPerpetual
-  ? require('./modules/perpetualApi')()
-  : TraderApi(config.apikey, config.apisecret, ...);
-```
-
-### ❌ Wrong Decimals
-
-```javascript
-// ❌ WRONG — hardcoded decimals
-const amount = baseAmount.toFixed(8);
-
-// ✅ CORRECT — use parsed market info
-const { coin1Decimals } = orderUtils.parseMarket(pair);
-const amount = baseAmount.toFixed(coin1Decimals);
-```
-
-### ❌ Forgetting Cache Invalidation
-
-```javascript
-// ❌ WRONG — stale cache after modification
-await traderapi.placeOrder(side, pair, price, amount);
-
-// ✅ CORRECT — invalidate cache
-await traderapi.placeOrder(side, pair, price, amount);
-orderUtils.clearCache(`${moduleName}/placedOrder`);
-```
-
-### ❌ Hard Dependencies at Module Level
-
-```javascript
-// ❌ WRONG — creates hard dependency, prevents feature toggling
-const lp = require('./mm_liquidity_provider');
-
-// ✅ CORRECT — soft dependency inside method
-if (tradeParams.mm_isLiquidityActive) {
-  const lp = require('./mm_liquidity_provider');
-  await lp.updateLiquidityAfterPriceChange(side, callerName);
-}
-```
-
-### ❌ Confusing Feature and Purpose
-
-```javascript
-// ❌ WRONG — 'vc' feature has no order purpose
-const orders = await db.ordersDb.find({ purpose: 'vc' }); // No such purpose!
-
-// ✅ CORRECT — 'vc' modifies trader behavior
-const coefficient = require('./mm_volatility_chart').getVolatilityCoefficient();
-```
-
-### ❌ Logging Sensitive Data
-
-```javascript
-// ❌ WRONG — never log API keys or passphrases
-log.log(`API keys: ${config.apikey}, ${config.apisecret}`);
-
-// ✅ CORRECT
-log.log(`Using exchange: ${config.exchangeName}`);
-```
-
----
-
-## Refactoring Guidance
-
-### Codebase Maturity
-
-This is a **mixed maturity codebase**:
-
-**Modern patterns** (refactored):
-
-- JSDoc type annotations (`@typedef`, `@param`, `@returns`)
-- Soft dependencies via `utils.softRequire()`
-- Clean error handling with module name and param details
-- Dynamic exchange loading
-
-**Legacy patterns** (pre-refactor):
-
-- Procedural code with loose coupling
-- Implicit dependencies / global state assumptions
-- Minimal type hints
-- Inconsistent error handling
-
-### Refactoring Rules
-
-**Bring all code toward modern patterns incrementally:**
-
-1. **Add JSDoc** type annotations when touching old code
-2. **Extract soft dependencies** — replace module-level `require()` with in-method loading
-3. **Add parameter validation** and informative error messages
-4. **Use `utils.softRequire()`** for optional feature modules
-5. **Enhance log messages** with context (module name, function, parameters)
-
-**Don't** do large refactors in one PR — each touch should incrementally improve consistency.
-
-### When Adding New Features
-
-- Use the iteration loop pattern
-- Add a `tradeParams` flag for enabling/disabling
-- Register as a `botFeature` in `commandTxs.js` if user-controllable
-- Add a unique order purpose if the feature places orders
-- Follow the error handling pattern with module name context
-- Clear cache after any order modifications
-- Support perpetual mode if applicable (check `config.perpetual`)
-
----
-
-## Quick Reference
-
-### Key Files
-
-| File | Purpose |
-| ------ | --------- |
-| `app.js` | Bootstrap entry point |
-| `modules/configReader.js` | Config loader (immutable) |
-| `modules/DB.js` | Database setup |
-| `modules/commandTxs.js` | Command parser, features |
-| `trade/orderUtils.js` | Order placement, caching, balance checks |
-| `trade/orderCollector.js` | Order cancellation/cleanup |
-| `trade/orderStats.js` | Statistics aggregation |
-| `helpers/fillsEngine.js` | Fill verification, VWAP |
-| `helpers/const.js` | Constants |
-| `helpers/utils.js` | Utilities |
-| `helpers/log.js` | Logging |
-| `helpers/notify.js` | Multi-channel notifications |
-| `helpers/dbModel.js` | DB ORM wrapper |
-| `trade/settings/tradeParams_Default.js` | Trade params template |
-
-### Important Constants
-
-```javascript
-constants.HOUR   = 3_600_000   // 60 * 60 * 1000
-constants.MINUTE = 60_000      // 60 * 1000
-constants.DAY    = 86_400_000  // 24 * 60 * 60 * 1000
-constants.REST_DATA_CACHE_MS = 1000  // Cache duration for REST data
-constants.MM_POLICIES = ['optimal', 'spread', 'orderbook', 'depth', 'wash']
-```
-
-### Feature Flags
-
-```javascript
-tradeParams.mm_isActive                  // Master kill switch
-tradeParams.mm_isTraderActive            // Volume maker
-tradeParams.mm_isOrderBookActive         // Order book builder
-tradeParams.mm_isLiquidityActive         // Liquidity provider
-tradeParams.mm_isPriceWatcherActive      // Price watcher
-tradeParams.mm_isPriceMakerActive        // Price maker
-tradeParams.mm_isCleanerActive           // Cleaner
-tradeParams.mm_isAntigapActive           // Anti-gap
-tradeParams.mm_isLadderActive            // Ladder
-tradeParams.mm_isSpreadMaintainerActive  // Spread maintainer
-tradeParams.mm_isQuoteHunterActive       // Quote hunter
-tradeParams.mm_isBalanceEqualizerActive  // Balance equalizer
-tradeParams.mm_isBalanceWatcherActive    // Balance watcher
-tradeParams.mm_isVolatilityActive        // Volatility chart
-tradeParams.mm_isVolumeVolatilityActive  // Volume volatility
-tradeParams.mm_isOrderNotifierActive     // Order notifier
-tradeParams.mm_isFundBalancerActive      // Fund balancer (2-key)
-t_isTwapActive                           // TWAP (independent of mm_isActive)
-```
-
-### Order Purposes
-
-`t` (trader), `ob` (orderbook), `obs` (orderbook spread), `liq` (liquidity), `sm` (spread), `ag` (antigap), `cl` (cleaner), `pw` (price watcher), `pm` (price maker), `qh` (quote hunter), `ld` (ladder), `tw` (twap), `be` (balance equalizer), `fs` (fund supplier), `tb` (trade bot), `man` (manual)
-
----
-
-## Communication
-
-- Developers communicate with AI in **any language**
-- ALL code, documentation, comments, commit messages **MUST be in English**
-- Use clear, descriptive variable/function names
-- Add comments for non-obvious logic
+It does not treat WebSocket or perpetual support as part of the default connector definition.

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -29,13 +29,13 @@ The goal is a small, reliable connector that works with the existing market-maki
 ```text
 trade/
 ├── trader_{exchange}.js
-└── api/
-    └── {exchange}_api.js
-│   ├── {exchange}_errors.js          # HTTP and exchange error code maps (RECOMMENDED)
+├── api/
+│   ├── {exchange}_api.js
+│   └── {exchange}_errors.js          # HTTP and exchange error code maps (RECOMMENDED)
 ├── tests/
 │   ├── trader_{exchange}.test.js     # Automated Jest tests
 │   ├── trader_{exchange}.mock.js     # Mock data for tests
-│   └── manual.test.js               # Manual test runner (shared)
+│   └── manual.test.js                # Manual test runner (shared)
 └── settings/
     └── tradeParams_{exchange}.js     # Exchange-specific param overrides (OPTIONAL)
 ```

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -49,6 +49,11 @@ trade/
 └── api/
     └── {exchange}_errors.js
 
+trade/tests/
+├── trader_{exchange}.test.js
+├── trader_{exchange}.mock.js
+└── manual.test.js
+
 types/
 └── {exchange}/...
 ```
@@ -114,6 +119,18 @@ If an optional capability is not implemented, expose that honestly in `features(
 ## Step 1: Build the Plain API Client
 
 **File**: `trade/api/{exchange}_api.js`
+
+### JSDoc is required
+
+For this repository, connector code should be documented with JSDoc in the same patch where it is added or changed.
+
+- Add JSDoc for all public functions
+- Add JSDoc for internal helper functions when their behavior is not obvious
+- Document all parameters with `@param`
+- Document return values with `@returns`
+- Reuse typedefs from `types/*.d.js` or `types/{exchange}/` where possible
+- Keep wording consistent with the repository writing style
+- Update JSDoc whenever function behavior, accepted inputs, or return shapes change
 
 This layer should only know exchange-specific HTTP details:
 
@@ -782,6 +799,11 @@ If such support is ever added to this repo later, document it separately after t
 ### Use JSDoc, but do not over-engineer it
 
 Document public methods and include links to the exchange docs when useful.
+
+- At minimum, every connector function should have a purpose line, `@param` entries for all parameters, and `@returns`
+- Parameter descriptions should explain semantics and constraints, not only the raw type
+- If a function returns `undefined` on failure, say that explicitly
+- If a function normalizes exchange-specific statuses or payload fields, document that mapping
 
 ### Prefer explicit validation over permissive fallbacks
 

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -4,6 +4,8 @@
 
 Read `ai-agent-instructions.md` first.
 
+Organization-wide governance rules from the ADAMANT org also apply here, especially English-only repository artifacts, issue and PR conventions, label policy, and linked governance references.
+
 ## Scope
 
 This guide describes the preferred baseline for the open-source branch: a basic **spot REST** connector.

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -1,47 +1,35 @@
-# AI Guide: Creating and Testing a New Exchange Connector
+# AI Guide: Building a Basic Exchange Connector for Tradebot OSS
 
-**Target Audience**: AI Coding Assistants (GitHub Copilot, Claude, Cursor, Windsurf, etc.)
+**Target audience**: AI coding assistants working in this repository.
 
-This guide provides step-by-step instructions for implementing and testing a complete exchange connector for the ADAMANT Trading Bot. It covers Spot REST, WebSocket, and Futures/Perpetual connectors.
+Read `ai-agent-instructions.md` first.
 
-**Prerequisites**: Read [ai-agent-instructions.md](ai-agent-instructions.md) first for overall architecture and development priorities.
+## Scope
 
----
+This guide describes the preferred baseline for the open-source branch: a basic **spot REST** connector.
 
-## Table of Contents
+Current connectors in `trade/trader_*.js` are not perfectly identical yet. Some older adapters expose extra methods or structure things a bit differently. That is acceptable for now. When adding a new connector or refreshing an old one, use this guide as the target direction.
 
-1. [Overview & File Structure](#overview--file-structure)
-2. [Step 1: Plain Exchange API Client](#step-1-plain-exchange-api-client)
-3. [Step 2: Error Descriptions File](#step-2-error-descriptions-file)
-4. [Step 3: Trader Adapter](#step-3-trader-adapter)
-5. [Step 4: Config & Registration](#step-4-config--registration)
-6. [Step 5: Testing Spot REST Connector](#step-5-testing-spot-rest-connector)
-7. [Step 6: WebSocket Connector (Optional)](#step-6-websocket-connector-optional)
-8. [Step 7: Perpetual/Futures Connector (Optional)](#step-7-perpetualfutures-connector-optional)
-9. [Step 8: Automated Tests](#step-8-automated-tests)
-10. [Step 9: MM Simulation Testing](#step-9-mm-simulation-testing)
-11. [Coding Guidelines](#coding-guidelines)
-12. [Return Shape Reference](#return-shape-reference)
-13. [Terminology Reference](#terminology-reference)
+### Important constraints
 
----
+- Baseline connectors are **spot only**
+- Baseline connectors are **REST only**
+- WebSocket support is **not required**
+- Perpetual or futures support is **out of scope**
+- Extended account, fee, transfer, and fund-history methods are usually **optional** in the first OSS version
 
-## Overview & File Structure
+The goal is a small, reliable connector that works with the existing market-making flow.
 
-Each exchange connector consists of several files that form a layered architecture:
+## Deliverables
+
+### Required files
 
 ```text
 trade/
-├── trader_{exchange}.js              # Bot-universal adapter (REQUIRED)
-├── api/
-│   ├── {exchange}_api.js             # Plain exchange REST API client (REQUIRED)
+├── trader_{exchange}.js
+└── api/
+    └── {exchange}_api.js
 │   ├── {exchange}_errors.js          # HTTP and exchange error code maps (RECOMMENDED)
-│   ├── websocket/
-│   │   ├── {exchange}WebsocketApi.js         # Public WS (market data)
-│   │   ├── {exchange}WebsocketPrivateApi.js  # Private WS (account data)
-│   │   └── {exchange}WebsocketPullApi.js     # WS pull (request-response)
-│   └── contract/
-│       └── {exchange}PerpetualApi.js         # Perpetual/Futures API
 ├── tests/
 │   ├── trader_{exchange}.test.js     # Automated Jest tests
 │   ├── trader_{exchange}.mock.js     # Mock data for tests
@@ -50,228 +38,228 @@ trade/
     └── tradeParams_{exchange}.js     # Exchange-specific param overrides (OPTIONAL)
 ```
 
-**Naming convention**: `{exchange}` is always **lowercase** (e.g., `binance`, `kucoin`, `bybit`).
-
-**Layering**:
+### Recommended files
 
 ```text
-Bot Trade Modules (mm_*.js)
-        │
-        ▼
-trader_{exchange}.js      ← Bot-universal interface (uniform method names & return shapes)
-        │
-        ▼
-{exchange}_api.js         ← Plain exchange HTTP client (exchange-specific params & responses)
-        │
-        ▼
-Exchange REST/WS API      ← External exchange servers
+trade/
+├── settings/
+│   └── tradeParams_{exchange}.js
+└── api/
+    └── {exchange}_errors.js
+
+types/
+└── {exchange}/...
 ```
 
----
+### Test inputs
 
-## Step 1: Plain Exchange API Client
+- `config.{exchange}_test.jsonc` or another exchange-specific local config
+- optional manual checks in `trade/tests/manual.test.js`
+
+## Baseline Connector Contract
+
+### Keep the factory signature compatible
+
+Even when the connector is REST-only, keep the existing trader factory signature so current call sites continue to work.
+
+```javascript
+const config = require('../modules/configReader');
+
+module.exports = (
+  apiKey,
+  secretKey,
+  pwd,
+  log,
+  publicOnly = false,
+  loadMarket = true,
+  useSocket = false,
+  useSocketPull = false,
+  accountNo = 0,
+  coin1 = config.coin1,
+  coin2 = config.coin2,
+) => {
+  // A basic OSS connector may ignore socket-related arguments.
+};
+```
+
+### Implement this method set first
+
+Required baseline methods:
+
+- `features()`
+- `getMarkets(pair?)`
+- `marketInfo(pair)`
+- `getBalances(nonzero?)`
+- `getOpenOrders(pair)`
+- `getOrderDetails(orderId, pair)`
+- `placeOrder(side, pair, price, coin1Amount, limit, coin2Amount)`
+- `cancelOrder(orderId, side, pair)`
+- `cancelAllOrders(pair, side?)`
+- `getRates(pair)`
+- `getOrderBook(pair)`
+- `getTradesHistory(pair)`
+
+Common optional methods:
+
+- `getCurrencies(coin?, forceUpdate?)`
+- `currencyInfo(coin)`
+- `getDepositAddress(coin)`
+- `getFees(coinOrPair)`
+- `withdraw(address, amount, coin, withdrawalFee, network)`
+
+If an optional capability is not implemented, expose that honestly in `features()` and avoid adding stub behavior that looks successful.
+
+## Step 1: Build the Plain API Client
 
 **File**: `trade/api/{exchange}_api.js`
 
-This module wraps the exchange's raw HTTP API. It handles authentication, request signing, and response/error classification.
+This layer should only know exchange-specific HTTP details:
 
-### Factory Function
+- base URL
+- authentication headers
+- request signing
+- endpoint paths and parameters
+- response classification
+
+It should not normalize responses into the bot's final shapes. That belongs in `trader_{exchange}.js`.
+
+### Recommended skeleton
 
 ```javascript
 const axios = require('axios');
-const config = require('../../modules/configReader');
 
 module.exports = function() {
-  let WEB_BASE; // API base URL
-  let config_apiKey;
-  let config_secretKey;
-  let config_tradePwd;
+  let apiServer;
+  let apiKey;
+  let secretKey;
+  let tradePassword;
   let log;
 
-  const EXCHANGE_API = {
-    setConfig(apiServer, apiKey, secretKey, tradePwd, logger, publicOnly) {
-      WEB_BASE = apiServer;
-      config_apiKey = apiKey;
-      config_secretKey = secretKey;
-      config_tradePwd = tradePwd;
-      log = logger;
-    },
-
-    // ... methods below
-  };
-
-  return EXCHANGE_API;
-};
-
-module.exports.axios = axios; // Exported for mock-adapter in tests
-```
-
-### `handleResponse()` — Response Classification
-
-This is the most critical method. It classifies every HTTP response into:
-
-- **Temporary error** → `reject()` (triggers retry in protectedRequest/publicRequest)
-- **Final error** → `resolve()` with error data (caller decides what to do)
-- **Success** → `resolve()` with parsed data
-
-```javascript
-handleResponse(responseOrError, resolve, reject, queryString, url) {
-  const httpCode = responseOrError?.status || responseOrError?.response?.status;
-  const httpMessage = responseOrError?.statusText || responseOrError?.response?.statusText;
-  const data = responseOrError?.data || responseOrError?.response?.data;
-
-  const reqParameters = queryString || '{ No parameters }';
-
-  // Determine success and exchange-specific error
-  const success = httpCode === 200 && data?.code === '200000'; // Exchange-specific
-  const exchangeError = getExchangeError(data); // Extract error code + message
-
-  // Build error description from {exchange}_errors.js
-  const error = buildErrorMessage(httpCode, exchangeError);
-
-  if (success) {
-    resolve(data.data || data);
-  } else if (error.isTemporary) {
-    // 5xx, 429, timeouts — reject for retry
-    log.warn(`Request to ${url} with data ${reqParameters} failed. ${error.description}, details: ${httpCode} ${httpMessage}, [${exchangeError.code}] ${exchangeError.msg}. Rejecting…`);
-    reject(error);
-  } else {
-    // 4xx, business errors — resolve with error info for caller
-    log.warn(`Request to ${url} with data ${reqParameters} failed. ${error.description}, details: ${httpCode} ${httpMessage}, [${exchangeError.code}] ${exchangeError.msg}. Resolving…`);
-    resolve({
-      // Include exchange error info for the caller
-      exchangeErrorInfo: exchangeError,
-    });
+  function setConfig(server, key, secret, pwd, logger) {
+    apiServer = server;
+    apiKey = key;
+    secretKey = secret;
+    tradePassword = pwd;
+    log = logger;
   }
-},
-```
 
-**Error message quality rules:**
+  function publicRequest(method, path, params) {
+    const url = `${apiServer}${path}`;
 
-- Include HTTP code AND message: `401 Unauthorized`
-- Include exchange error code AND message: `[400004] KC-API-PASSPHRASE error`
-- No double spacing, no double dots, no missing codes
-- Distinguish between "Rejecting" (temporary, will retry) and "Resolving" (final, caller handles)
-
-### `publicRequest()` and `protectedRequest()`
-
-```javascript
-publicRequest(type, path, params) {
-  const url = `${WEB_BASE}${path}`;
-  return new Promise((resolve, reject) => {
-    const config = {
-      method: type,
+    return axios({
+      method,
       url,
       params,
-      headers: { 'Content-Type': 'application/json' },
       timeout: 10000,
-    };
+    })
+        .then((response) => handleResponse(response, path, params))
+        .catch((error) => handleResponse(error, path, params));
+  }
 
-    axios(config)
-        .then((response) => EXCHANGE_API.handleResponse(response, resolve, reject, JSON.stringify(params), url))
-        .catch((error) => EXCHANGE_API.handleResponse(error, resolve, reject, JSON.stringify(params), url));
-  });
-},
+  function protectedRequest(method, path, data) {
+    const url = `${apiServer}${path}`;
+    const timestamp = Date.now();
 
-protectedRequest(type, path, data) {
-  const url = `${WEB_BASE}${path}`;
-  const timestamp = Date.now();
-
-  // Build signature (exchange-specific: HMAC-SHA256, Ed25519, etc.)
-  const signature = buildSignature(timestamp, type, path, data, config_secretKey);
-
-  return new Promise((resolve, reject) => {
-    const config = {
-      method: type,
+    return axios({
+      method,
       url,
       data,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-API-KEY': config_apiKey,
-        'X-API-SIGN': signature,
-        'X-API-TIMESTAMP': timestamp,
-        // Exchange-specific headers...
-      },
       timeout: 10000,
+      headers: buildHeaders(method, path, data, timestamp),
+    })
+        .then((response) => handleResponse(response, path, data))
+        .catch((error) => handleResponse(error, path, data));
+  }
+
+  function buildHeaders(method, path, data, timestamp) {
+    return {
+      'Content-Type': 'application/json',
+      'X-API-KEY': apiKey,
+      'X-API-SIGN': signRequest(method, path, data, timestamp, secretKey),
+      'X-API-TIMESTAMP': timestamp,
+      'X-API-PASSPHRASE': tradePassword,
     };
+  }
 
-    axios(config)
-        .then((response) => EXCHANGE_API.handleResponse(response, resolve, reject, JSON.stringify(data), url))
-        .catch((error) => EXCHANGE_API.handleResponse(error, resolve, reject, JSON.stringify(data), url));
-  });
-},
+  function handleResponse(responseOrError, path, payload) {
+    const httpCode = responseOrError?.status || responseOrError?.response?.status;
+    const httpMessage = responseOrError?.statusText || responseOrError?.response?.statusText;
+    const data = responseOrError?.data || responseOrError?.response?.data;
+
+    const result = classifyResponse(httpCode, data);
+
+    if (result.ok) {
+      return result.data;
+    }
+
+    const details = `${httpCode ?? 'No code'} ${httpMessage ?? 'No message'}`;
+    const requestData = JSON.stringify(payload ?? {});
+
+    if (result.temporary) {
+      const error = new Error(`Request ${path} failed temporarily. ${details}. Payload: ${requestData}. ${result.message}`);
+      log.warn(error.message);
+      throw error;
+    }
+
+    log.warn(`Request ${path} failed. ${details}. Payload: ${requestData}. ${result.message}`);
+    return result.data;
+  }
+
+  return {
+    setConfig,
+    markets() {},
+    getBalances() {},
+    getOrders() {},
+    getOrder() {},
+    addOrder() {},
+    cancelOrder() {},
+    cancelAllOrders() {},
+    ticker() {},
+    orderBook() {},
+    getTradesHistory() {},
+  };
+};
+
+module.exports.axios = axios;
 ```
 
-### Exchange-Specific API Methods
+### Response classification rules
 
-Implement low-level methods that map directly to exchange API endpoints. Names can differ from the bot's interface:
+At this layer, distinguish three cases:
 
-```javascript
-// Required methods (names are free-form, matched in trader_{exchange}.js)
-getBalances(params) { ... }          // Account balances
-getOrders(pair, status) { ... }      // Open/closed orders
-getOrder(orderId) { ... }            // Single order details
-addOrder(params) { ... }             // Place an order
-cancelOrder(orderId) { ... }         // Cancel an order
-cancelAllOrders(pair) { ... }        // Cancel all orders
-ticker(pair) { ... }                 // 24h market ticker
-orderBook(pair, limit) { ... }       // Order book depth
-markets() { ... }                    // All trading pairs info
-currencies() { ... }                 // All currencies info
-getTradesHistory(pair) { ... }       // Recent trades
-getDepositAddress(coin) { ... }      // Deposit address
-getFees(pair) { ... }                // Trading fees
+1. Success: return parsed exchange payload
+2. Temporary failure: throw or reject so the caller can retry or abort safely
+3. Final failure: return structured error data so the trader adapter can decide what to do
 
-// Optional methods
-getAccounts() { ... }                // Account info
-transferFunds(params) { ... }        // Internal transfer
-getDepositHistory(params) { ... }    // Deposit history
-getWithdrawalHistory(params) { ... } // Withdrawal history
-addWithdrawal(params) { ... }        // Create withdrawal
-getVolume() { ... }                  // Account trading volume
-getCandlesHistory()                  // Candles data
-```
+Typical temporary failures:
 
-**JSDoc for each method must include a link to the exchange API documentation:**
+- HTTP `429`
+- HTTP `5xx`
+- network timeout
+- temporary gateway failures
 
-```javascript
-/**
- * Get account balances
- * https://docs.exchange.com/api/v1/account/balances
- * @param {object} params
- * @returns {Promise<object>}
- */
-getBalances(params) { ... }
-```
+Typical final failures:
 
----
+- invalid API key
+- invalid params
+- unknown order id
+- insufficient balance
 
-## Step 2: Error Descriptions File
+### Optional error map file
 
-**File**: `trade/api/{exchange}_errors.js`
-
-If the exchange provides clear error codes, create a separate error descriptions file:
+If the exchange has a stable error-code catalog, create `trade/api/{exchange}_errors.js`.
 
 ```javascript
 const httpErrorCodeDescriptions = {
-  4: { description: 'Client error' },
-  400: { description: 'Bad request' },
-  401: { description: 'Invalid API Key' },
-  403: { description: 'Forbidden' },
-  404: { description: 'Not found' },
+  401: { description: 'Invalid API key' },
   429: { description: 'Rate limit exceeded', isTemporary: true },
-  5: { description: 'Server error', isTemporary: true },
-  502: { description: 'Bad gateway', isTemporary: true },
   503: { description: 'Service unavailable', isTemporary: true },
+  5: { description: 'Server error', isTemporary: true },
 };
 
 const exchangeErrorCodeDescriptions = {
-  '400001': { description: 'Insufficient balance' },
-  '400002': { description: 'Order does not exist' },
-  '400003': { description: 'Invalid parameter' },
-  '400004': { description: 'API key passphrase error' },
-  '429000': { description: 'Too many requests', isTemporary: true },
-  // ... all exchange-specific codes
+  '1001': { description: 'Insufficient balance' },
+  '2001': { description: 'Order does not exist' },
 };
 
 module.exports = {
@@ -280,60 +268,57 @@ module.exports = {
 };
 ```
 
-**Key rules:**
+Keep it small and useful. Do not add hundreds of speculative mappings no one will read.
 
-- `isTemporary: true` → `handleResponse` will `reject()` (retry via axios retry)
-- Without `isTemporary` → `handleResponse` will `resolve()` with error info (caller handles)
-- Map both HTTP codes (4xx, 5xx) and exchange-specific numeric/string codes
-- Use generic catch-alls: key `4` matches any 4xx, key `5` matches any 5xx
-
----
-
-## Step 3: Trader Adapter
+## Step 2: Build the Trader Adapter
 
 **File**: `trade/trader_{exchange}.js`
 
-This is the bot-universal interface. It converts between the bot's standard method signatures/return shapes and the exchange-specific API.
+This layer converts exchange-native responses into the bot's common shapes.
 
-### Factory Function Signature (STRICT)
+### Recommended structure
 
 ```javascript
 const config = require('../modules/configReader');
+const utils = require('../helpers/utils');
 const ExchangeApi = require('./api/{exchange}_api');
 
+const apiServer = 'https://api.exchange.example';
+const exchangeName = 'ExampleExchange';
+
 module.exports = (
-    apiKey,
-    secretKey,
-    pwd,
-    log,
-    publicOnly = false,
-    loadMarket = true,
-    useSocket = false,
-    useSocketPull = false,
-    accountNo = 0,
-    coin1 = config.coin1,
-    coin2 = config.coin2,
+  apiKey,
+  secretKey,
+  pwd,
+  log,
+  publicOnly = false,
+  loadMarket = true,
+  useSocket = false,
+  useSocketPull = false,
+  accountNo = 0,
+  coin1 = config.coin1,
+  coin2 = config.coin2,
 ) => {
   const exchangeApiClient = ExchangeApi();
+
   exchangeApiClient.setConfig(apiServer, apiKey, secretKey, pwd, log, publicOnly);
 
-  // Load markets on init
   if (loadMarket) {
     getMarkets();
-    if (!publicOnly) {
-      getCurrencies(); // Only if auth endpoints needed
-    }
   }
 
-  // Return the public interface object
   return {
-    get markets() { ... },
-    get currencies() { ... },
-    getMarkets,
-    getCurrencies,
-    marketInfo,
-    currencyInfo,
+    get markets() {
+      return module.exports.exchangeMarkets;
+    },
+
+    get currencies() {
+      return module.exports.exchangeCurrencies;
+    },
+
     features,
+    getMarkets,
+    marketInfo,
     getBalances,
     getOpenOrders,
     getOrderDetails,
@@ -343,160 +328,159 @@ module.exports = (
     getRates,
     getOrderBook,
     getTradesHistory,
-    getCandlesHistory,
-    getDepositAddress,
-    getFees,
-    getAccount,
-    transfer,
-    withdraw,
-    getWithdrawalById,
-    processHistoryRecords,
   };
 };
 ```
 
-### Shared Module-Level State
+### Shared module-level caches
 
-Markets and currencies are cached on `module.exports` for cross-instance sharing:
+This pattern already exists in current OSS connectors and is safe to keep.
 
 ```javascript
-module.exports.exchangeMarkets = {};       // Cached market data
-module.exports.exchangeCurrencies = {};    // Cached currency data
-module.exports.gettingMarkets = false;     // Guard against concurrent fetches
+module.exports.exchangeMarkets = {};
+module.exports.exchangeCurrencies = {};
+module.exports.gettingMarkets = false;
 module.exports.gettingCurrencies = false;
 ```
 
-### Required Methods (Names Are STRICT)
+### `features()` for a basic OSS connector
 
-Every method below MUST exist and return data in the [standardized shapes](#return-shape-reference).
-
-#### `features(pair?)`
-
-Returns exchange capability flags. The bot checks these to decide what features to enable:
+Expose only what you actually support.
 
 ```javascript
-function features(pair) {
+function features() {
   return {
     getMarkets: true,
-    getCurrencies: true,
-    supportCoinNetworks: true,          // Currencies include network info
-    placeMarketOrder: true,             // Exchange supports market orders
-    allowAmountForMarketBuy: true,      // Market buy can use base amount
-    allowAmountForMarketSell: true,     // Market sell can use base amount
-    amountForMarketOrderNecessary: false, // Market order REQUIRES amount (not quote)
-    getDepositAddress: true,
+    getCurrencies: false,
+    placeMarketOrder: false,
+    allowAmountForMarketBuy: false,
+    amountForMarketOrderNecessary: false,
+    getDepositAddress: false,
     createDepositAddressWithWebsiteOnly: false,
-    selfTradeProhibited: true,          // Exchange prevents self-trade
-    getTradingFees: true,
+    supportCoinNetworks: false,
+    supportCoinNetworksRestricted: false,
+    getTradingFees: false,
     getAccountTradeVolume: false,
-    getFundHistory: true,
-    getFundHistoryImplemented: true,
-    getWithdrawalById: true,
-    supportTransferBetweenAccounts: true,
-    accountTypes: ['spot', 'funding'],  // Available account types
-    tradingAccountType: 'spot',         // Which account is used for trading
-    orderNumberLimit: 200,              // Max open orders per pair
-    apiProcessingDelayMs: 10,           // Delay after order placement for API consistency
-    isDemo: false,                      // Demo/testnet account
-    // Socket features (only if WebSocket is implemented)
+    getFundHistory: false,
+    getFundHistoryImplemented: false,
+    supportTransferBetweenAccounts: false,
+    accountTypes: false,
+    tradingAccountType: 'trade',
+    selfTradeProhibited: false,
+    orderNumberLimit: undefined,
+    apiProcessingDelayMs: undefined,
     socketSupport: false,
     socketPullSupport: false,
-    socketEnabled: useSocket,
-    // Data source for candle-based indicators
-    marketDataSource: 'candles',        // 'candles' or 'trades'
+    socketEnabled: false,
   };
 }
 ```
 
-#### `formatPairName(pair)` — Internal Helper
+If the exchange supports more, add only the fields you can verify.
 
-Defined OUTSIDE the factory function (at file bottom), parses any pair format:
+### Pair parsing helper
+
+Define pair formatting helpers once and reuse them.
 
 ```javascript
-/**
- * Parses any pair format to standardized names
- * @param {string} pair E.g. BTC/USDT, BTC-USDT, BTC_USDT, BTCUSDT
- * @returns {{ coin1: string, coin2: string, pair: string, pairReadable: string, pairPlain: string, isParsed: boolean }}
- */
 function formatPairName(pair) {
-  pair = pair?.toUpperCase();
-  // Split into coin1 and coin2 based on exchange's separator
-  // ...
+  const upperPair = pair?.toUpperCase();
+
+  if (!upperPair?.includes('/')) {
+    return {
+      pairReadable: upperPair,
+      pairPlain: upperPair,
+      coin1: undefined,
+      coin2: undefined,
+    };
+  }
+
+  const [coin1, coin2] = upperPair.split('/');
+
   return {
     coin1,
     coin2,
-    pair: coin1 + coin2,            // BTCUSDT (no separator)
-    pairReadable: `${coin1}/${coin2}`, // BTC/USDT
-    pairPlain: `${coin1}-${coin2}`,    // BTC-USDT (exchange's native format)
-    isParsed: true,
+    pairReadable: `${coin1}/${coin2}`,
+    pairPlain: `${coin1}_${coin2}`,
   };
 }
 ```
 
-#### `formatNetworkName(networkName)` — Internal Helper
+The exact `pairPlain` format depends on the exchange.
 
-Maps exchange-specific network names to the bot's standard network codes using `helpers/networks.js`:
+### `getMarkets()`
 
-```javascript
-const networks = require('../../helpers/networks');
+This method is the foundation for decimals, minimums, and pair validation.
 
-function formatNetworkName(networkName) {
-  // Exchange might call it 'ETHEREUM', 'ETH', 'erc20', 'ERC-20', etc.
-  // Map to standard: 'ERC20', 'BEP20', 'TRC20', 'SOL', etc.
-  const mapped = networks.findNetwork(networkName);
-  return mapped?.code || networkName;
-}
-```
+Required fields per market object:
 
-#### `getMarkets(pair?)`
+- `pairReadable`
+- `pairPlain`
+- `coin1`
+- `coin2`
+- `coin1Decimals`
+- `coin2Decimals`
+- `coin1Precision`
+- `coin2Precision`
+- `coin1MinAmount`
+- `coin1MaxAmount`
+- `coin2MinPrice`
+- `coin2MaxPrice`
+- `coin2MinAmount` when known
+- `minTrade`
+- `status`
 
-Fetches all trading pairs from the exchange. Stores results in `module.exports.exchangeMarkets`.
+Example shape:
 
 ```javascript
 async function getMarkets(pair) {
-  // Return cached if available and no specific pair requested
-  if (module.exports.exchangeMarkets && !pair) {
-    return module.exports.exchangeMarkets;
+  if (module.exports.gettingMarkets) return;
+
+  if (module.exports.exchangeMarkets && pair) {
+    return module.exports.exchangeMarkets[formatPairName(pair).pairPlain];
   }
 
-  // Guard against concurrent fetches
-  if (module.exports.gettingMarkets) return;
   module.exports.gettingMarkets = true;
 
-  try {
-    const data = await exchangeApiClient.markets();
-    if (!data) return undefined;
+  let markets;
 
+  try {
+    markets = await exchangeApiClient.markets();
+  } catch (error) {
+    log.warn(`API request getMarkets() failed. ${error}`);
+    module.exports.gettingMarkets = false;
+    return undefined;
+  }
+
+  try {
     const result = {};
-    for (const market of data) {
-      const pairNames = formatPairName(`${market.baseAsset}/${market.quoteAsset}`);
+
+    for (const market of markets) {
+      const pairNames = formatPairName(`${market.base}/${market.quote}`);
 
       result[pairNames.pairPlain] = {
         pairReadable: pairNames.pairReadable,
         pairPlain: pairNames.pairPlain,
         coin1: pairNames.coin1,
         coin2: pairNames.coin2,
-        coin1Decimals: getDecimalsFromStep(market.stepSize),
-        coin2Decimals: getDecimalsFromStep(market.tickSize),
-        coin1Precision: +market.stepSize,
-        coin2Precision: +market.tickSize,
-        coin1MinAmount: +market.minQty,
-        coin1MaxAmount: +market.maxQty,
-        coin2MinAmount: +market.minNotional,
-        coin2MaxAmount: null,
+        coin1Decimals: +market.amountPrecision,
+        coin2Decimals: +market.pricePrecision,
+        coin1Precision: utils.getPrecision(+market.amountPrecision),
+        coin2Precision: utils.getPrecision(+market.pricePrecision),
+        coin1MinAmount: +market.minAmount,
+        coin1MaxAmount: +market.maxAmount || null,
+        coin2MinAmount: +market.minNotional || null,
         coin2MinPrice: +market.minPrice || null,
         coin2MaxPrice: +market.maxPrice || null,
-        minTrade: +market.minNotional,
-        status: market.status === 'TRADING' ? 'ONLINE' : 'OFFLINE',
+        minTrade: +market.minAmount,
+        status: market.active ? 'ONLINE' : 'OFFLINE',
       };
     }
 
     module.exports.exchangeMarkets = result;
-    log.log(`Received info about ${Object.keys(result).length} markets on ${config.exchangeName} exchange.`);
-
-    return result;
-  } catch (e) {
-    log.warn(`API request getMarkets() of trader_${config.exchange}.js module failed. ${e}`);
+    return pair ? result[formatPairName(pair).pairPlain] : result;
+  } catch (error) {
+    log.warn(`Error while processing getMarkets() response: ${error}`);
     return undefined;
   } finally {
     module.exports.gettingMarkets = false;
@@ -504,852 +488,329 @@ async function getMarkets(pair) {
 }
 ```
 
-**Important**: Keys in `exchangeMarkets` should be `pairPlain` (exchange's native format like `BTC-USDT`), not `pairReadable`.
+### `marketInfo(pair)`
 
-#### `getCurrencies(coin?)`
-
-Similar to `getMarkets()` but for currencies. Stores results in `module.exports.exchangeCurrencies`. Must include:
-
-- Basic info: `symbol`, `name`, `status`, `decimals`, `precision`
-- Network info (if exchange provides): `networks` object with `{ withdrawalFee, minWithdrawal, confirmations, status, chainName }`
-- Use `formatNetworkName()` for network keys
-
-#### `marketInfo(pair)` and `currencyInfo(coin)`
-
-Return locally cached info for a specific pair/currency:
+Keep it simple.
 
 ```javascript
 function marketInfo(pair) {
-  const pairNames = formatPairName(pair);
-  return module.exports.exchangeMarkets?.[pairNames.pairPlain];
+  return module.exports.exchangeMarkets?.[formatPairName(pair).pairPlain];
 }
 ```
 
-#### `getBalances(nonzero = true, accountType)`
+### Two-stage `try/catch` rule
 
-Returns array of balance objects. Each method has **two separate try-catch blocks**: one for the API request, one for data processing.
+For methods that call the exchange, use one `try/catch` for the request and one for normalization.
+
+This avoids mixing transport failures with payload-shape failures.
+
+### `getBalances(nonzero = true)`
+
+Return:
 
 ```javascript
-async function getBalances(nonzero = true, accountType) {
-  const paramString = `nonzero: ${nonzero}, accountType: ${accountType}`;
-
-  let data;
-  try {
-    data = await exchangeApiClient.getBalances({ type: accountType || 'trade' });
-  } catch (e) {
-    log.warn(`API request getBalances(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
-    return undefined;
-  }
-
-  try {
-    const result = [];
-    for (const balance of data) {
-      const free = +balance.available;
-      const freezed = +balance.frozen;
-      const total = free + freezed;
-      if (nonzero && total === 0) continue;
-
-      result.push({ code: balance.currency, free, freezed, total });
-    }
-    return result;
-  } catch (e) {
-    log.warn(`Error while processing getBalances(${paramString}) response: ${e}`);
-    return undefined;
-  }
-}
+[{ code: 'BTC', free: 1.2, freezed: 0.3, total: 1.5 }]
 ```
 
-**Critical**: In case of ANY error (API or processing), return `undefined`. This eliminates false results. If the method returns data, it must accurately reflect exchange state.
+On request or parsing failure, return `undefined`.
 
-**Critical**: Code in `catch()` blocks must be reliable and never fail. No sensitive operations in catch blocks.
+### `getOpenOrders(pair)`
 
-#### `getOpenOrders(pair)`
+Return only open or partially filled orders.
 
-If the exchange paginates results, implement a private `getOpenOrdersPage()` helper and call it in a loop.
+Required order fields:
 
-Return array of order objects with statuses: `new` or `part_filled` (never `filled` — these are open orders).
+- `orderId`
+- `symbol`
+- `price`
+- `side`
+- `type`
+- `timestamp`
+- `amount`
+- `amountExecuted`
+- `amountLeft`
+- `status`
 
-#### `getOrderDetails(orderId, pair)`
+Allowed statuses here:
 
-Returns detailed info about a single order. Important for fill verification.
+- `new`
+- `part_filled`
 
-Statuses: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
+If the exchange paginates, implement `getOpenOrdersPage()` and loop until done.
 
-- API error (500, timeout) → return `undefined`
-- Order not found → return `{ status: 'unknown' }`
-- Wrong orderId format → return `{ status: 'unknown' }` or `undefined`
-- Order found → return full details with correct status
+### `getOrderDetails(orderId, pair)`
 
-#### `placeOrder(side, pair, price, coin1Amount, limit = 1, coin2Amount)`
+This method is important for order tracking and reconciliation.
 
-The most complex method. Must handle 10 order variants:
+Expected statuses:
 
-1. **Limit buy** with `coin1Amount` (base amount)
-2. **Limit buy** with `coin2Amount` (quote amount)
-3. **Limit sell** with `coin1Amount`
-4. **Limit sell** with `coin2Amount`
-5. **Limit buy** at price that fills immediately
-6. **Limit sell** at price that fills immediately
-7. **Market buy** with `coin1Amount`
-8. **Market buy** with `coin2Amount`
-9. **Market sell** with `coin1Amount`
-10. **Market sell** with `coin2Amount`
+- `unknown`
+- `new`
+- `filled`
+- `part_filled`
+- `cancelled`
 
-**Pre-validation checklist:**
+Recommended behavior:
+
+- temporary API problem: `undefined`
+- order not found: `{ orderId, status: 'unknown' }`
+- found order: normalized detail object
+
+### `placeOrder(side, pair, price, coin1Amount, limit = 1, coin2Amount)`
+
+This is the highest-risk method in the connector.
+
+Required checks before sending the request:
+
+1. the market exists
+2. amount and price round correctly to exchange precision
+3. rounded amount is still positive
+4. minimum amount and notional constraints are satisfied
+5. side and order type are mapped correctly for the exchange API
+
+Recommended return shapes:
 
 ```javascript
-async function placeOrder(side, pair, price, coin1Amount, limit = 1, coin2Amount) {
-  const paramString = `side: ${side}, pair: ${pair}, price: ${price}, coin1Amount: ${coin1Amount}, limit: ${limit}, coin2Amount: ${coin2Amount}`;
+{ orderId: '12345', message: 'Order placed ...' }
+{ orderId: false, message: 'Insufficient funds' }
+undefined
+```
 
-  // 1. Check market info exists
-  const marketData = marketInfo(pair);
-  if (!marketData) {
-    log.warn(`Unable to place order on ${pair}: no market info.`);
-    return { message: `No market info for ${pair}` };
-  }
+Do not claim success without a real exchange order id.
 
-  // 2. Calculate amount/quote with correct decimals
-  // 3. Validate min/max amounts
-  // 4. Validate min/max price
-  // 5. Build exchange-specific order params
+### `cancelOrder(orderId, side, pair)`
 
-  try {
-    const data = await exchangeApiClient.addOrder(orderParams);
-    // ...
-    if (data?.orderId) {
-      return { orderId: String(data.orderId), message: undefined };
-    } else {
-      return { orderId: undefined, message: data?.message || 'Unknown error' };
-    }
-  } catch (e) {
-    log.warn(`API request placeOrder(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
-    return undefined;
-  }
+Recommended results:
+
+- `true`: cancelled or already absent in a safe, understood way
+- `false`: final business failure
+- `undefined`: transport or processing failure
+
+### `cancelAllOrders(pair, side)`
+
+Prefer the exchange bulk-cancel endpoint when it exists.
+
+### `getRates(pair)`
+
+Return a compact ticker object:
+
+```javascript
+{
+  ask: 1.01,
+  bid: 1.00,
+  last: 1.005,
+  volume: 100000,
+  volumeInCoin2: 100500,
+  high: 1.08,
+  low: 0.98,
 }
 ```
 
-**If placing fails after pre-checks** (invalid params, insufficient min amount): log and return `{ message: '...' }` with `orderId: undefined`.
+### `getOrderBook(pair)`
 
-#### `cancelOrder(orderId, side, pair)`
+Return:
 
-- Order cancelled → `true`
-- Order not found / already cancelled → `false`
-- Wrong orderId format → `false` or `undefined`
-- API error → `undefined`
+```javascript
+{
+  bids: [{ amount: 10, price: 1.0, count: 1, type: 'bid-buy-left' }],
+  asks: [{ amount: 12, price: 1.1, count: 1, type: 'ask-sell-right' }],
+}
+```
 
-#### `cancelAllOrders(pair)`
+Rules:
 
-- Orders cancelled → `true`
-- No open orders → `true`
-- Pair doesn't exist → `false` or `undefined`
+- bids sorted by price descending
+- asks sorted by price ascending
+- numeric fields must be numbers, not strings
 
-#### `getRates(pair)`
+### `getTradesHistory(pair)`
 
-Returns 24h ticker. Pair doesn't exist → `undefined`.
+Return ascending by timestamp.
 
-#### `getOrderBook(pair)`
+```javascript
+[{ coin1Amount: 10, price: 1.01, coin2Amount: 10.1, date: 1700000000000, type: 'buy', tradeId: 'abc' }]
+```
 
-Returns `{ bids, asks }`. Bids sorted by price descending, asks ascending. If API allows, request 200 items with no grouping (plain order book).
+## Step 3: Add Optional Currency and Deposit Methods Later
 
-#### `getTradesHistory(pair)`
+If the exchange exposes useful currency metadata, then add:
 
-Returns array sorted by timestamp ascending. If API allows, request 300 items.
+- `getCurrencies()`
+- `currencyInfo()`
+- `getDepositAddress()`
 
-#### `getCandlesHistory(pair, timeframe, since, limit, excludeLast?)`
+These are useful, but they are not the first thing that makes the market-making loop safe.
 
-Returns OHLCV candle data array.
+When currency networks exist, normalize network names through `helpers/networks.js` or a small exchange-specific mapping.
 
-#### `getDepositAddress(coin)`
+## Step 4: Register the Exchange
 
-Returns array of `{ network, address, memo? }`. Use `formatNetworkName()` for network names. Return addresses for all networks where deposits are enabled.
+### Create a config file for testing
 
-#### `getFees(coinOrPair)`
-
-- If `coinOrPair` is a coin (e.g., BTC): return fees for all pairs where this coin is base
-- If `coinOrPair` is a pair: return fees for that pair
-- If neither provided: return fees for all pairs (if possible) or `undefined`
-- Returns `[{ pair, makerRate, takerRate }]`
-
-#### `transfer(coin, from, to, amount)`
-
-Internal account transfer (e.g., spot → funding). If `amount` not set, transfer full balance. Returns `{ success, errorMessage? }`.
-
-#### `withdraw(address, amount, coin, withdrawalFee, network)`
-
-External withdrawal. `withdrawalFee` is sent ON TOP of `amount`. Returns `{ success, id?, errorMessage? }`.
-
-#### `getDepositHistory(coin, limit)` and `getWithdrawalHistory(coin, limit)`
-
-Via `processHistoryRecords(target, coin, limit)`. Returns array of history records.
-
-#### `getWithdrawalById(id)`
-
-Single withdrawal record lookup.
-
-#### `getVolume()`
-
-Account's 24h trading volume. Returns `[{ updated, volume30days, volumeUnit }]`.
-
-#### `getAccount()`
-
-Account basic info.
-
----
-
-## Step 4: Config & Registration
-
-### Create Config File
-
-Copy `config.default.jsonc` → `config.{exchange}_test.jsonc`:
+The runtime resolves custom config names through `node app.js <name>`, so a test file can look like this:
 
 ```jsonc
 {
-  "exchange": "Newexchange",  // Exchange name (capital first letter)
+  "exchange": "Exampleexchange",
   "pair": "BTC/USDT",
-  "apikey": "your-api-key",
-  "apisecret": "your-api-secret",
-  "apipassword": "",          // If exchange requires API passphrase
+  "apikey": "your-key",
+  "apisecret": "your-secret",
+  "apipassword": "",
+  "admin_accounts": [],
+  "socket": true,
   "api": {
-    "port": 1111,
-    "ip": "0.0.0.0",
-    "health_check": true,
-    "debug_info": true
-  }
-  // ...other settings
-}
-```
-
-### Register Exchange Name
-
-Add the exchange name to the `exchanges` array in `config.default.jsonc`:
-
-```jsonc
-"exchanges": [
-  // ... existing exchanges
-  "Newexchange"
-]
-```
-
-### Trade Params Override (Optional)
-
-If an exchange needs different default parameters, create `trade/settings/tradeParams_{exchange}.js`. Otherwise, the bot copies `tradeParams_Default.js` automatically at startup.
-
----
-
-## Step 5: Testing Spot REST Connector
-
-### Testing Tools
-
-1. **Logging**: `console.log()` in API methods (temporary, remove before PR)
-2. **Bot commands**: `/balances`, `/orders`, `/rates`, `/buy`, `/sell`, etc.
-3. **Manual test runner**: Set `"dev": true` in config, use `trade/tests/manual.test.js`:
-   - Uncomment the desired test block (e.g., `test_spot()`)
-   - Add method calls inside the function
-   - Run: `node app.js {config_name}`
-   - Methods execute a few seconds after bot starts
-
-```javascript
-// In trade/tests/manual.test.js — test_spot() function
-console.log(await traderapi.cancelOrder('5d13f3e8-dcb3-4a6d-88c1-16cf6e8d8179', undefined, 'DOGE/USDT'));
-console.log(await traderapi.getOpenOrders('BTC/USDT'));
-console.log(await traderapi.placeOrder('buy', 'BTC/USDT', 30000, 0.001, 1));
-```
-
-### Start Testing
-
-Run: `node app.js {config_name}` (or `npm run start:config -- {config_name}`)
-
-On successful startup, you should see:
-
-1. Connected to MongoDB
-2. Received info about N markets on Exchange
-3. Received info about N currencies on Exchange (if applicable)
-4. API server listening
-5. Bot started notification
-
-### Testing `handleResponse()` — Request Processing
-
-Add temporary logging after the request parameters line in `{exchange}_api.js`:
-
-```javascript
-console.log(`Request to ${url} returned ${httpCode} ${httpMessage}`);
-console.log(`success is ${success}`);
-console.log(`exchangeError is ${JSON.stringify(exchangeError)}`);
-console.log(`error is ${JSON.stringify(error)}`);
-// console.log(`data is ${data}`); // Only for failed requests — too verbose for success
-```
-
-#### Test: Server Timeout
-
-Set `timeout: 1` instead of `timeout: 10000` in `publicRequest()`.
-
-**Expected**: Request rejected, good-looking error message with `AxiosError: timeout of 1ms exceeded`.
-
-#### Test: Invalid API Keys
-
-Use wrong API keys in config, send `/balances`.
-
-**Expected**:
-
-- Request resolved (not rejected — auth errors are final)
-- Error message includes HTTP code, message, exchange error code and message
-- Example: `401 Unauthorized, [400004] KC-API-PASSPHRASE error`
-
-**Bad output examples** (fix if you see these):
-
-- Missing HTTP code: `Unauthorized, [400004] ...`
-- Double spacing: `401 Unauthorized,  [400004] ...`
-- Double dot: `...error.. Rejecting…`
-- Not enough details: `...details: 400004. Rejecting…`
-
-#### Test: Resolved Errors
-
-When a request errors with a final state, it must resolve (not reject) with error info:
-
-```javascript
-// Test: cancel a non-existent order
-console.log(await traderapi.cancelOrder('non-existent-id', undefined, 'DOGE/USDT'));
-// Should return false (not throw), with good log message
-```
-
-### Testing Individual Methods
-
-For each method below, check:
-
-1. The connected API method and its documentation
-2. Log BOTH raw request results AND processed results
-3. Compare with exchange UI
-4. All numbers stored as numbers, not strings
-
-#### `getMarkets(pair)`
-
-```javascript
-// Add logging inside getMarkets():
-if (market.symbol === 'KCS-BTC') {
-  console.log('Plain data:', market);
-  console.log(`${market.symbol} -> ${JSON.stringify(pairNames)}`);
-  console.log('Formatted data:', result[pairNames.pairPlain]);
-}
-```
-
-**Verify:**
-
-- All fields present: `pairReadable`, `pairPlain`, `coin1`, `coin2`, `coin1Decimals`, `coin2Decimals`, `coin1MinAmount`, `coin1MaxAmount`, `status`, etc.
-- `coin1Decimals`, `coin2Decimals` match exchange UI
-- `formatPairName()` produces correct results
-- Market count matches exchange documentation
-- Keys in `exchangeMarkets` are `pairPlain`, not `pairReadable`
-
-#### `getCurrencies(coin?)`
-
-```javascript
-// Add logging:
-console.log(`${chainName} -> ${formatNetworkName(chainName)}`);
-if (currency.currency === 'USDT') {
-  console.log('Plain data:', currency);
-  console.log('Formatted data:', result[currency.currency]);
-}
-```
-
-**Verify:**
-
-- All fields present: `symbol`, `name`, `status`, `decimals`, `precision`, `networks`
-- `formatNetworkName()` maps all exchange networks to standard codes (ERC20, BEP20, TRC20, SOL, etc.)
-- Network objects include: `status`, `depositStatus`, `withdrawalStatus`, `confirmations`, `withdrawalFee`, `chainName`
-- If currencies use auth endpoint, only fetch when `publicOnly === false`
-- Currency count matches exchange documentation
-- Network info matches what exchange UI shows for deposits/withdrawals
-
-#### `marketInfo(pair)` and `currencyInfo(coin)`
-
-Quick check: return cached data for a specific pair/coin.
-
-#### `features()`
-
-Verify all flags match exchange API documentation and capabilities.
-
-#### `getBalances(nonzero, accountType)`
-
-Test via logging, `/balances` command, and direct execution.
-
-**Verify**: Each crypto has `code`, `free`, `freezed`, `total`. Compare with exchange UI.
-
-#### `getOpenOrders(pair)`
-
-**Expected results:**
-
-- Pair doesn't exist → `undefined`
-- No open orders → empty array `[]`
-- Has open orders → array with: `orderId` (string), `symbol`, `symbolPlain`, `price` (number), `side`, `type`, `timestamp` (ms), `amount` (number), `amountExecuted` (number), `amountLeft` (number), `status` (`new` or `part_filled`)
-
-**Test `part_filled`**: Place a sell order in spread, then a buy at same price with lower amount:
-
-```javascript
-const testPrice = 0.0002162;
-const testMarket = 'KCS/BTC';
-await traderapi.placeOrder('sell', testMarket, testPrice, 0.2);
-await traderapi.placeOrder('buy', testMarket, testPrice, 0.1);
-await traderapi.getOpenOrders(testMarket);
-// The sell order should now be part_filled
-```
-
-#### `getOrderDetails(orderId, pair)`
-
-Test ALL statuses: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
-
-Test `filled` with both limit and market orders (buy and sell).
-
-**Expected:**
-
-- API error → `undefined`
-- Order not found → `{ status: 'unknown' }`
-- Wrong orderId format → `{ status: 'unknown' }` or `undefined`
-- Order found → `orderId`, `pairReadable`, `pairPlain`, `price`, `side`, `type`, `timestamp`, `amount`, `volume`, `amountExecuted`, `volumeExecuted`, `status`
-
-#### `cancelOrder(orderId, side, pair)`
-
-- Exists and cancelled → `true`
-- Not found / already cancelled → `false`
-- Wrong format → `false` or `undefined`
-
-#### `cancelAllOrders(pair)`
-
-- Pair doesn't exist → `false` or `undefined`
-- No open orders → `true`
-- Orders cancelled → `true`
-
-#### `getRates(pair)`
-
-- Pair doesn't exist → `undefined`
-- Otherwise → `{ ask, bid, last, volume, volumeInCoin2, high, low }` (all numbers)
-
-#### `placeOrder(side, pair, price, coin1Amount, limit, coin2Amount)`
-
-Test all 10 order types listed in [Step 3: placeOrder](#placeorderside-pair-price-coin1amount-limit--1-coin2amount).
-
-**Additional tests:**
-
-- Insufficient balance
-- Wrong parameters
-- Small-price pairs (price < 10⁻⁸)
-- Amount below exchange minimum
-- Volume below exchange minimum
-- Precision higher than allowed
-
-Check the `/balances` after each order to verify `free`, `freezed`, `total` match expectations.
-
-**Verify**: Log messages and reply messages to admins are consistent and good-looking.
-
-#### `getTradesHistory(pair)`
-
-- Pair doesn't exist → `undefined`
-- Otherwise → array of `{ coin1Amount, price, coin2Amount, date, type, tradeId? }` sorted by timestamp ascending. 300 items if API allows.
-
-#### `getOrderBook(pair)`
-
-- Pair doesn't exist → `undefined`
-- Otherwise → `{ bids: [{ amount, price, count, type }], asks: [...] }`. Bids desc, asks asc. 200 items if API allows. No order grouping.
-
-#### `getDepositAddress(coin)`
-
-- Returns `[{ network, address, memo? }]`
-- `network` formatted via `formatNetworkName()`
-- Returns all networks where deposits are enabled
-- Test multi-network coins (USDT) and single-network (DASH, ADM)
-- Error → `{ success: false, message }` or `undefined`
-
-#### `transfer(coin, from, to, amount)`
-
-- Check `/balances full` before and after
-- If no amount specified, transfers full balance
-- Error → `{ success: false, errorMessage }`
-
-#### `withdraw(address, amount, coin, withdrawalFee, network)`
-
-- Withdraw to your own account and verify arrival
-- `withdrawalFee` is ON TOP of `amount`
-- Check via `/show withdrawals` and `/balances full`
-- Success → `{ success: true, id, currency, amount, address, withdrawalFee, ... }`
-- Error → `{ success: false, errorMessage }`
-
-#### `getDepositHistory(coin, limit)` and `getWithdrawalHistory(coin, limit)`
-
-Test via `/show deposits` and `/show withdrawals`. Error → `{ success: false, errorMessage }`.
-
-#### `getWithdrawalById(id)`
-
-Test via `/show withdrawal {ID}`.
-
-#### `getFees(coinOrPair)`
-
-- Works for both coins and pairs
-- For a coin → fees for all pairs where coin is base
-- Neither coin nor pair → fees for all pairs or `undefined`
-- Returns `[{ pair, makerRate, takerRate }]`
-- Non-existent coin/pair → empty array or `undefined`
-
-#### `getVolume()`
-
-Returns `[{ updated, volume30days, volumeUnit }]`. Error → `undefined`.
-
----
-
-## Step 6: WebSocket Connector (Optional)
-
-WebSocket extends the REST connector with real-time data. Three priority levels:
-
-1. **WS Subscription** (highest) — real-time push
-2. **WS Pull** — request-response over WS
-3. **REST** (lowest) — traditional HTTP polling
-
-### File Structure
-
-```text
-trade/api/websocket/
-├── websocketApi.js                       # Generic WS base class (DO NOT MODIFY)
-├── {exchange}WebsocketApi.js             # Public WS (market data)
-├── {exchange}WebsocketPrivateApi.js      # Private WS (account data)
-└── {exchange}WebsocketPullApi.js         # WS pull (request-response)
-```
-
-### Architecture
-
-- **Base class** `WebSocketApi` handles: connection lifecycle, heartbeat, reconnection, and a `store` with data channels (`depth`, `trades`, `balance`, `orders`, `rates`) and validity tracking
-- Exchange implementations extend `WebSocketApi` and override: `subscribe()`, `initEvents()`, `removeEvents()`, `auth()`, `fetchInitialData()`
-
-### Trader Adapter Modifications
-
-When WS is implemented, modify `trader_{exchange}.js`:
-
-1. Add to `features()`:
-
-```javascript
-socketSupport: true,
-socketPullSupport: true,
-socketEnabled: useSocket,
-```
-
-2. Add WS helper methods:
-
-```javascript
-isPublicWsEnabled(dataName, pairObj) { ... }
-isPrivateWsEnabled(dataName, pairObj) { ... }
-wsPublicPullEnabled(pullMethod) { ... }
-wsPrivatePullEnabled(pullMethod) { ... }
-```
-
-3. Amend data methods to prefer WS over REST:
-
-```javascript
-async function getRates(pair) {
-  // Priority: WS subscription → WS pull → REST
-  if (isPublicWsEnabled('rates', pairObj)) {
-    return wsApiClient.store.rates[pairPlain];
-  }
-  if (wsPublicPullEnabled('getRates')) {
-    return wsApiClient.pullRates(pairPlain);
-  }
-  // Fallback to REST
-  return getRestRates(pair);
-}
-```
-
-### Methods to Implement
-
-#### Public WS
-
-| Method | WS Subscription | WS Pull |
-| -------- | ---------------- | --------- |
-| `getRates(pair)` | Yes | Yes |
-| `getOrderBook(pair)` | Yes (subscribe to diffs with checksum, not full book) | Yes |
-| `getTradesHistory(pair)` | Yes (subscribe to new trades, fill history via pull/REST) | Yes |
-
-**Order book** is usually maintained via differential updates:
-
-- Initially fill via WS pull or REST snapshot
-- Subscribe to add/remove/amend events
-- Verify integrity via checksum (if exchange provides)
-- Re-subscribe on checksum mismatch
-
-#### Private WS
-
-| Method | WS Subscription | WS Pull |
-| -------- | ---------------- | --------- |
-| `getBalances` | Yes (subscribe to balance changes) | Yes |
-| `getOpenOrders` | Yes (subscribe to order changes) | Yes |
-| `getOrderDetails` | — | Yes (handler) |
-| `cancelOrder` | — | Yes (handler) |
-| `placeOrder` | — | Yes (handler) |
-
----
-
-## Step 7: Perpetual/Futures Connector (Optional)
-
-### Architecture
-
-```text
-modules/perpetualApi.js              # Singleton factory (loads exchange-specific impl)
-trade/api/contract/
-├── perpetualApi.js                  # Abstract base class (DO NOT MODIFY)
-└── {exchange}PerpetualApi.js        # Exchange-specific implementation
-```
-
-### Key Differences from Spot
-
-- Pair naming: `BTCUSDT` (perpetual) vs `BTC/USDT` (spot)
-- `buy/sell` ≡ `long/short` in context
-- Set `isDemoAccount: true` in config for testing before live
-- Most trade modules DO NOT work with perpetual (only `mm_trader` and `mm_orderbook_builder`)
-
-### Implementation Pattern
-
-```javascript
-const PerpetualApi = require('./perpetualApi');
-
-class ExchangePerpetualApi extends PerpetualApi {
-  constructor(params) {
-    super(params);
-    // Create spotApi (plain API client) and traderApi (trader adapter)
-    this.spotApi = ExchangeApiClient();
-    this.traderApi = TraderFactory(params.apiKey, params.secretKey, ...);
-  }
-
-  // Override abstract methods...
-}
-```
-
-Reuse spot methods where possible. If `getOrderBook()` is 70% shared between spot and perpetual, modify the spot method to be universal rather than duplicating.
-
-### Methods to Implement
-
-| Method | Notes |
-| -------- | ------- |
-| `features()` | Perpetual-specific capabilities |
-| `formatPairName(pair)` | Returns `pairPerpetual: 'BTCUSDT'` |
-| `getBalances(nonzero, accountType)` | Futures account balances |
-| `getFees(coinOrPair, category)` | May differ from spot |
-| `getInstruments(symbol, forceUpdate)` | Like spot's `getMarkets()` |
-| `instrumentInfo(symbol)` | Like spot's `marketInfo()` |
-| `getOrderBook(symbol, limit)` | Often reuses spot implementation |
-| `getTickerInfo(symbol)` | Includes perpetual-specific: open interest, mark price |
-| `getPublicTradeHistory(symbol, limit)` | Recent trades |
-| `getOpenInterest(intervalTime)` | Open interest data |
-| `getLongShortRatio(intervalTime)` | Long/short ratio |
-| `getRiskLimit(symbol)` | Max leverage & caps |
-| `placeOrder(symbol, side, type, qty, price, reduceOnly, ...)` | Long/short with leverage |
-| `cancelOrder(orderId, symbol, side)` | Cancel perpetual order |
-| `cancelAllOrders(symbol, side)` | Cancel all perpetual orders |
-| `getOpenOrders(symbol)` | Unfilled/partially filled |
-| `getOrderDetails(orderId)` | Order info |
-| `getPositions(symbol)` | Open positions with PnL |
-| `closePosition(symbol, price?)` | Close at limit or market |
-| `setLeverage(symbol, leverage)` | Set leverage |
-| `switchMarginMode(symbol, mode, leverage)` | `isolated` or `cross` |
-| `switchPositionMode(symbol, mode)` | `oneway` or `hedge` |
-| `setTakeProfitStopLoss(symbol, tp, sl, ...)` | TP/SL management |
-
-### Modules Compatibility with Perpetual
-
-| Module | Perpetual | Notes |
-| -------- | ----------- | ------- |
-| `mm_trader` | Yes | Single account only |
-| `mm_orderbook_builder` | Yes | — |
-| All other `mm_*` modules | **No** | Return error: "The feature {name} is not available for perpetual contract trading." |
-| Two-key trading | **No** | `useSecondAccount = traderapi2 && !isPerpetual` |
-| `cs_manager` | **No** | — |
-
----
-
-## Step 8: Automated Tests
-
-**File**: `trade/tests/trader_{exchange}.test.js`
-
-Use Jest with `axios-mock-adapter` to test without real API calls:
-
-```javascript
-const MockAdapter = require('axios-mock-adapter');
-const exchangeApi = require('../api/{exchange}_api');
-const { axios } = exchangeApi;
-
-const config = require('../../modules/configReader');
-const TraderFactory = require('../trader_' + config.exchange);
-
-let mock;
-let traderapi;
-
-beforeAll(async () => {
-  mock = new MockAdapter(axios);
-  traderapi = TraderFactory(
-      config.apikey, config.apisecret, config.apipassword,
-      console, false, true, false, false, 0, config.coin1, config.coin2,
-  );
-
-  // Mock getMarkets response
-  mock.onGet('/api/v2/symbols').reply(200, require('./trader_{exchange}.mock').marketsResponse);
-  await traderapi.getMarkets();
-});
-
-afterAll(() => mock.restore());
-
-describe('trader_{exchange}', () => {
-  test('getBalances returns correct shape', async () => {
-    mock.onGet('/api/v1/accounts').reply(200, mockBalancesResponse);
-    const balances = await traderapi.getBalances(false);
-    expect(balances).toBeInstanceOf(Array);
-    expect(balances[0]).toHaveProperty('code');
-    expect(balances[0]).toHaveProperty('free');
-    expect(typeof balances[0].free).toBe('number');
-  });
-
-  test('placeOrder returns orderId', async () => {
-    mock.onPost('/api/v1/orders').reply(200, { code: '200000', data: { orderId: '123' } });
-    const result = await traderapi.placeOrder('buy', 'BTC/USDT', 30000, 0.001, 1);
-    expect(result).toHaveProperty('orderId', '123');
-  });
-
-  // ... test each method
-});
-```
-
-**Mock data file**: `trade/tests/trader_{exchange}.mock.js` — export mock API response objects.
-
----
-
-## Step 9: MM Simulation Testing
-
-After all individual methods pass, run a full market-making simulation:
-
-1. **Choose a trading pair with rare trading activity** (to control the environment)
-2. **Enable features**: `t` (trader, in-spread strategy, small amounts), `ob`, `ag`, `ld`, `liq`
-3. **Run the bot** and carefully monitor:
-   - Logs for errors, warnings, unexpected behavior
-   - Trading pair's order book, trade history, and chart on exchange website
-   - Bot replies to commands: `/balances`, `/orders`, `/rates`, `/stats`
-4. **Critical check**: There must be NO `unk` (unknown) orders when you run `/orders`. If there are, something is wrong with order tracking.
-5. **Watch for**:
-   - Orders placed at correct prices and amounts
-   - Orders cancelled properly when modules rotate
-   - Balances tracked accurately
-   - No duplicate orders
-   - Correct spread maintenance
-
----
-
-## Coding Guidelines
-
-### Mandatory Connector Quality Rules
-
-These rules are mandatory for every new connector and connector refactor.
-
-1. **Strict JSDoc and typedef usage**
-
-Add detailed JSDoc for all public methods in both `trade/api/{exchange}_api.js` and `trade/trader_{exchange}.js`. Use typedef imports from `types/*.d.js` in the same style as `trade/trader_binance.js`.
-
-2. **Endpoint response types are required**
-
-Create exchange-specific endpoint response typedef files under `types/{exchange}/`, include realistic `@example` payloads, and apply those typedefs in API and trader files (avoid untyped endpoint payloads).
-
-3. **Direct API docs links in API method JSDoc**
-
-Every API method in `trade/api/{exchange}_api.js` must include a direct URL to the exact official endpoint documentation.
-
-4. **Describe enum values and parameter semantics in JSDoc**
-
-Do not leave enum-like parameters undocumented (for example, avoid bare `@param {0 | 1 | 2 | 3 | 4} typeTrade`). Always explain each meaningful value and usage constraints in JSDoc and in `types/{exchange}/*.d.js`.
-
-5. **No silent response-shape masking**
-
-Do not hide malformed payloads with permissive patterns like `response?.list || []`. Validate response shape explicitly and log/handle invalid payloads.
-
-6. **Use `marketInfo()` in candle normalization paths**
-
-In trader adapters, candle parsing must use `marketInfo()` metadata (decimals/precision), not ad-hoc market reloading.
-
-7. **Use exchange bulk cancellation endpoint**
-
-If exchange supports bulk order cancellation, `cancelAllOrders()` must use that endpoint as primary path.
-
-8. **Extract reusable helpers**
-
-Before introducing local helper logic, check `helpers/utils.js`. If helper can be reused across modules, add it to `helpers/utils.js` and use it from there.
-
-9. **Mandatory test evidence and reports**
-
-Provide detailed raw and normalized outputs for connector tests, explicitly cover `getOrderDetails` status normalization (`unknown`, `new`, `filled`, `part_filled`, `cancelled`), and save reports as separate files per mode: `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-mock) ... .md` for mock runs and `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-live) ... .md` for live runs.
-
-10. **Exchange trade params file policy**
-
-`trade/settings/tradeParams_{exchange}.js` must contain a full copied object from `tradeParams_Default.js`. Do not re-export default trade params with `require('./tradeParams_Default')`.
-
-11. **Markdown lint compliance is mandatory**
-
-All Markdown documentation must pass markdownlint rules, including `MD022` (blanks around headings), `MD032` (blanks around lists), `MD007` (list indentation), `MD034` (no bare URLs), and `MD040` (fenced code language).
-
-12. **Use explicit exchange-prefixed typedef names**
-
-Avoid ambiguous `default` typedef names in `types/{exchange}/*.d.js`. Use human-readable exchange-prefixed names (for example, `DextradeSymbols`, `DextradeTicker`, `DextradeOrder`) and import the exact named typedef in API and trader files.
-
-13. **One-line description punctuation rule**
-
-For one-line parameter/property/list descriptions, do not use a trailing period if there is only one sentence. If there are two or more sentences, keep terminal periods after each sentence.
-
-### String Quoting
-
-- **Single quotes** everywhere: code, JSDoc, comments
-- Exception: separate `*.d.js` type definition files may use double quotes
-
-```javascript
-// ❌ WRONG
-/** @param {"delete" | "get" | "post"} method */
-/** @param {string} pair E.g. "BTC/USDT" */
-
-// ✅ CORRECT
-/** @param {'delete' | 'get' | 'post'} method */
-/** @param {string} pair E.g. BTC/USDT */
-
-// ✅ CORRECT — long strings should be quoted
-/** @param {string} orderId Example: 'a9625b04-fc66-4999-a876-543c3684d702' */
-```
-
-### Async/Await
-
-All methods in `trader_{exchange}.js` use `async/await`, **not** Promises.
-
-Exception: `getMarkets()` and `getCurrencies()` may still use Promise-based implementation, but `async/await` is preferred for new connectors.
-
-### Error Handling
-
-Every method has two separate try-catch blocks:
-
-```javascript
-async function someMethod(params) {
-  const paramString = `params: ${JSON.stringify(params)}`;
-
-  // Block 1: API request
-  let data;
-  try {
-    data = await exchangeApiClient.someEndpoint(params);
-  } catch (e) {
-    log.warn(`API request someMethod(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
-    return undefined;
-  }
-
-  // Block 2: Data processing
-  try {
-    // Process data...
-    return processedResult;
-  } catch (e) {
-    log.warn(`Error while processing someMethod(${paramString}) response: ${e}`);
-    return undefined;
+    "port": 3000,
+    "health": true,
+    "debug": true
+  },
+  "db": {
+    "name": "tradebotdb",
+    "url": "mongodb://127.0.0.1:27017/"
   }
 }
 ```
 
-### Linter
+Save it as `config.exampleexchange_test.jsonc` and run:
 
-Always run `npm run lint` before submitting. Rules are in `eslint.config.js`.
+```bash
+node app.js exampleexchange_test
+```
 
----
+### Update exchange lists if needed
+
+If the config validator or docs rely on the exchange name list, update `config.default.jsonc` accordingly.
+
+### Add exchange-specific trade params only when necessary
+
+If the defaults are good enough, do not create `trade/settings/tradeParams_{exchange}.js` yet.
+
+## Step 5: Manual Testing
+
+The practical OSS testing path is straightforward.
+
+### Use the built-in manual runner in dev mode
+
+`trade/tests/manual.test.js` already contains examples for direct method checks.
+
+Useful checks:
+
+- `features()`
+- `marketInfo()`
+- `getRates()`
+- `getOrderBook()`
+- `getTradesHistory()`
+- `getOpenOrders()`
+- `placeOrder()`
+- `getOrderDetails()`
+- `cancelOrder()`
+- `cancelAllOrders()`
+
+Run it with:
+
+```bash
+npm run start:dev
+```
+
+or
+
+```bash
+node app.js dev
+```
+
+### Minimum acceptance checklist
+
+Before calling a basic connector ready, verify all of this:
+
+1. `getMarkets()` loads and `marketInfo(config.pair)` returns sane decimals and minimums
+2. `getRates()` returns numbers
+3. `getOrderBook()` returns sorted asks and bids
+4. `getTradesHistory()` returns ascending trades
+5. `getBalances()` matches the exchange UI closely enough
+6. `placeOrder()` returns a real order id on success
+7. `getOpenOrders()` can see the placed order
+8. `getOrderDetails()` reports the right status transitions
+9. `cancelOrder()` or `cancelAllOrders()` removes the order cleanly
+
+### Recommended live test sequence
+
+Use a quiet pair and very small safe amounts.
+
+1. Load markets and ticker
+2. Place one small limit order far from market price
+3. Confirm it appears in open orders
+4. Fetch its order details
+5. Cancel it
+6. Confirm it disappears from open orders
+
+If any of these steps are unreliable, the connector is not ready for the market-making loop.
+
+## Step 6: Keep the First Version Small
+
+For the OSS branch, a connector is already useful when it can support the active spot modules safely.
+
+Do not block delivery of a good REST connector because the exchange also has:
+
+- a WebSocket API
+- a funding API
+- internal account transfer APIs
+- perpetual contracts
+- dozens of secondary endpoints
+
+Those can be added later if the branch genuinely starts using them.
+
+## Explicitly Out of Scope for the Baseline
+
+These topics are intentionally excluded from the default connector definition in this repository:
+
+- public WebSocket subscriptions
+- private WebSocket account streams
+- WebSocket pull APIs
+- perpetual or futures contract adapters
+- leverage, margin mode, position mode, TP or SL management
+- compatibility matrices for spot vs perpetual modules
+
+If such support is ever added to this repo later, document it separately after the plain REST spot connector already works.
+
+## Coding Rules
+
+### Use JSDoc, but do not over-engineer it
+
+Document public methods and include links to the exchange docs when useful.
+
+### Prefer explicit validation over permissive fallbacks
+
+Bad:
+
+```javascript
+const orders = response?.data?.list || [];
+```
+
+Better:
+
+```javascript
+if (!Array.isArray(response?.data?.list)) {
+  log.warn('Invalid getOpenOrders() payload');
+  return undefined;
+}
+```
+
+### Keep catch blocks safe
+
+Catch blocks should only log and return. Do not add fragile logic there.
+
+### Reuse repo helpers when it helps
+
+Useful helpers already exist in:
+
+- `helpers/utils.js`
+- `helpers/networks.js`
+- `trade/orderUtils.js`
+
+### Run lint before finishing
+
+```bash
+npm run lint
+```
 
 ## Return Shape Reference
 
@@ -1359,178 +820,71 @@ Always run `npm run lint` before submitting. Rules are in `eslint.config.js`.
 [{ code: 'BTC', free: 0.5, freezed: 0.1, total: 0.6 }]
 ```
 
-### Open Orders
+### Open orders
 
 ```javascript
 [{
-  orderId: '12345',          // string
-  symbol: 'BTC/USDT',       // pairReadable
-  symbolPlain: 'BTC-USDT',  // pairPlain
-  price: 30000,             // number
-  side: 'buy',              // 'buy' | 'sell'
-  type: 'limit',            // 'limit' | 'market'
-  timestamp: 1701820952000, // ms unix
-  amount: 0.001,            // number, base amount
-  amountExecuted: 0,        // number
-  amountLeft: 0.001,        // number
-  status: 'new',            // 'new' | 'part_filled'
-  // Optional:
-  fee: 0.00001,             // number
+  orderId: '12345',
+  symbol: 'BTC/USDT',
+  price: 30000,
+  side: 'buy',
+  type: 'limit',
+  timestamp: 1701820952000,
+  amount: 0.001,
+  amountExecuted: 0,
+  amountLeft: 0.001,
+  status: 'new',
 }]
 ```
 
-### Order Details
+### Order details
 
 ```javascript
 {
   orderId: '12345',
   pairReadable: 'BTC/USDT',
-  pairPlain: 'BTC-USDT',
-  price: 30000,              // number
+  pairPlain: 'BTC_USDT',
+  price: 30000,
   side: 'buy',
   type: 'limit',
-  timestamp: 1701820952000,  // ms unix
-  amount: 0.001,             // number
-  volume: 30,                // number, coin2 amount
-  amountExecuted: 0.001,     // number
-  volumeExecuted: 30,        // number
-  status: 'filled',          // 'unknown' | 'new' | 'filled' | 'part_filled' | 'cancelled'
-  // Optional:
-  totalFeeInCoin2: 0.03,     // number
-  updateTimestamp: 1701820960000,
-  tradesCount: 1,
+  timestamp: 1701820952000,
+  amount: 0.001,
+  volume: 30,
+  amountExecuted: 0.001,
+  volumeExecuted: 30,
+  status: 'filled',
 }
 ```
 
-### Order Book
+### Place order result
 
 ```javascript
-{
-  bids: [{ amount: 0.5, price: 29999, count: 1, type: 'bid' }],   // desc by price
-  asks: [{ amount: 0.3, price: 30001, count: 1, type: 'ask' }],   // asc by price
-}
+{ orderId: '12345', message: 'Order placed ...' }
+{ orderId: false, message: 'Insufficient funds' }
+undefined
 ```
 
-### Rates / Ticker
+### Rates
 
 ```javascript
 { ask: 30001, bid: 29999, last: 30000, volume: 1234.5, volumeInCoin2: 37035000, high: 30500, low: 29500 }
 ```
 
-### Place Order
-
-```javascript
-{ orderId: '12345', message: undefined }          // Success
-{ orderId: undefined, message: 'Insufficient funds' }  // Pre-check failure
-undefined                                          // API error
-```
-
-### Trade History
-
-```javascript
-[{
-  coin1Amount: 0.001,        // number
-  price: 30000,              // number
-  coin2Amount: 30,           // number
-  date: 1701820952000,       // ms unix
-  type: 'buy',               // 'buy' | 'sell'
-  tradeId: 'abc123',         // string, optional
-}]
-// Sorted by timestamp ascending
-```
-
-### Fees
-
-```javascript
-[{ pair: 'BTC/USDT', makerRate: 0.001, takerRate: 0.001 }]
-```
-
-### Market Info
+### Order book
 
 ```javascript
 {
-  pairReadable: 'BTC/USDT',
-  pairPlain: 'BTC-USDT',
-  coin1: 'BTC',
-  coin2: 'USDT',
-  coin1Decimals: 8,          // number of decimal places for base amount
-  coin2Decimals: 2,          // number of decimal places for quote price
-  coin1Precision: 0.00000001, // smallest step for base
-  coin2Precision: 0.01,       // smallest step for quote
-  coin1MinAmount: 0.00001,
-  coin1MaxAmount: 9000,
-  coin2MinAmount: 10,         // min notional / min quote
-  coin2MaxAmount: null,
-  coin2MinPrice: 0.01,
-  coin2MaxPrice: 1000000,
-  minTrade: 10,               // Legacy, duplicates coin2MinAmount or coin1MinAmount
-  status: 'ONLINE',           // 'ONLINE' | 'OFFLINE'
+  bids: [{ amount: 0.5, price: 29999, count: 1, type: 'bid-buy-left' }],
+  asks: [{ amount: 0.3, price: 30001, count: 1, type: 'ask-sell-right' }],
 }
 ```
 
-### Currency Info
+### Trades history
 
 ```javascript
-{
-  symbol: 'USDT',
-  name: 'USDT',
-  status: 'ONLINE',
-  comment: undefined,
-  confirmations: 0,
-  withdrawalFee: undefined,    // May be per-network
-  minWithdrawal: undefined,
-  maxWithdrawal: undefined,
-  logoUrl: undefined,
-  exchangeAddress: undefined,
-  decimals: 8,
-  precision: 0.00000001,
-  minSize: undefined,
-  type: undefined,
-  networks: {
-    ERC20: {
-      withdrawalFee: 3.5,
-      minWithdrawal: 10,
-      confirmations: 12,
-      status: 'ONLINE',
-      chainName: 'ETH',       // Exchange's raw name
-      chainId: 'eth',         // Exchange's raw ID, if available
-      chainMappedCode: 'ERC20',     // From networks.js
-      chainMappedName: 'Ethereum',  // From networks.js
-    },
-    // ...more networks
-  },
-  defaultNetwork: undefined,
-}
+[{ coin1Amount: 0.001, price: 30000, coin2Amount: 30, date: 1701820952000, type: 'buy', tradeId: 'abc123' }]
 ```
 
-### Deposit Address
+## Final Rule of Thumb
 
-```javascript
-[{ network: 'ERC20', address: '0x...', memo: undefined }]
-// Or on error:
-{ success: false, message: 'No deposit address found' }
-```
-
----
-
-## Terminology Reference
-
-| Term | Definition |
-| ------ | ----------- |
-| **pairReadable** | Human-readable pair format: `ADM/USDT` |
-| **pairPlain** | Exchange's native pair format: `ADM-USDT`, `ADM_USDT`, `ADMUSDT` |
-| **pairPerpetual** | Perpetual contract format: `ADMUSDT` (no separator) |
-| **coin1 / base** | First currency in pair (the asset being traded) |
-| **coin2 / quote** | Second currency in pair (the pricing currency) |
-| **bid** | Buy orders (below current price, green, left side of order book) |
-| **ask** | Sell orders (above current price, red, right side of order book) |
-| **decimals** | Number of decimal places. `decimals=4` → `0.0041` |
-| **precision** | Smallest unit derived from decimals. `decimals=4` → `precision=0.0001` |
-| **isTemporary** | Error that may succeed on retry (5xx, timeouts, rate limits) |
-| **publicOnly** | Create API instance without private endpoint initialization |
-| **loadMarket** | Whether to fetch market/currency lists on init (default: true) |
-| **reduceOnly** | Perpetual: order can only reduce position size, never increase |
-| **funding rate** | Perpetual: periodic fee exchanged between longs and shorts |
-| **open interest** | Perpetual: total contracts currently held on the platform |
-| **margin mode** | Perpetual: `isolated` (limited loss) or `cross` (full balance at risk) |
-| **position mode** | Perpetual: `oneway` (single direction) or `hedge` (both directions) |
+For this repository, a good new connector is not the most feature-rich one. It is the smallest connector that safely supports spot trading, order tracking, and the active market-making modules without pretending unsupported features exist.

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -303,8 +303,12 @@ module.exports = (
 
   exchangeApiClient.setConfig(apiServer, apiKey, secretKey, pwd, log, publicOnly);
 
+  // Load markets on init
   if (loadMarket) {
     getMarkets();
+    if (!publicOnly) {
+      getCurrencies(); // Only if auth endpoints needed
+    }
   }
 
   return {

--- a/.github/exchange-connector-guide.md
+++ b/.github/exchange-connector-guide.md
@@ -1,0 +1,1536 @@
+# AI Guide: Creating and Testing a New Exchange Connector
+
+**Target Audience**: AI Coding Assistants (GitHub Copilot, Claude, Cursor, Windsurf, etc.)
+
+This guide provides step-by-step instructions for implementing and testing a complete exchange connector for the ADAMANT Trading Bot. It covers Spot REST, WebSocket, and Futures/Perpetual connectors.
+
+**Prerequisites**: Read [ai-agent-instructions.md](ai-agent-instructions.md) first for overall architecture and development priorities.
+
+---
+
+## Table of Contents
+
+1. [Overview & File Structure](#overview--file-structure)
+2. [Step 1: Plain Exchange API Client](#step-1-plain-exchange-api-client)
+3. [Step 2: Error Descriptions File](#step-2-error-descriptions-file)
+4. [Step 3: Trader Adapter](#step-3-trader-adapter)
+5. [Step 4: Config & Registration](#step-4-config--registration)
+6. [Step 5: Testing Spot REST Connector](#step-5-testing-spot-rest-connector)
+7. [Step 6: WebSocket Connector (Optional)](#step-6-websocket-connector-optional)
+8. [Step 7: Perpetual/Futures Connector (Optional)](#step-7-perpetualfutures-connector-optional)
+9. [Step 8: Automated Tests](#step-8-automated-tests)
+10. [Step 9: MM Simulation Testing](#step-9-mm-simulation-testing)
+11. [Coding Guidelines](#coding-guidelines)
+12. [Return Shape Reference](#return-shape-reference)
+13. [Terminology Reference](#terminology-reference)
+
+---
+
+## Overview & File Structure
+
+Each exchange connector consists of several files that form a layered architecture:
+
+```text
+trade/
+├── trader_{exchange}.js              # Bot-universal adapter (REQUIRED)
+├── api/
+│   ├── {exchange}_api.js             # Plain exchange REST API client (REQUIRED)
+│   ├── {exchange}_errors.js          # HTTP and exchange error code maps (RECOMMENDED)
+│   ├── websocket/
+│   │   ├── {exchange}WebsocketApi.js         # Public WS (market data)
+│   │   ├── {exchange}WebsocketPrivateApi.js  # Private WS (account data)
+│   │   └── {exchange}WebsocketPullApi.js     # WS pull (request-response)
+│   └── contract/
+│       └── {exchange}PerpetualApi.js         # Perpetual/Futures API
+├── tests/
+│   ├── trader_{exchange}.test.js     # Automated Jest tests
+│   ├── trader_{exchange}.mock.js     # Mock data for tests
+│   └── manual.test.js               # Manual test runner (shared)
+└── settings/
+    └── tradeParams_{exchange}.js     # Exchange-specific param overrides (OPTIONAL)
+```
+
+**Naming convention**: `{exchange}` is always **lowercase** (e.g., `binance`, `kucoin`, `bybit`).
+
+**Layering**:
+
+```text
+Bot Trade Modules (mm_*.js)
+        │
+        ▼
+trader_{exchange}.js      ← Bot-universal interface (uniform method names & return shapes)
+        │
+        ▼
+{exchange}_api.js         ← Plain exchange HTTP client (exchange-specific params & responses)
+        │
+        ▼
+Exchange REST/WS API      ← External exchange servers
+```
+
+---
+
+## Step 1: Plain Exchange API Client
+
+**File**: `trade/api/{exchange}_api.js`
+
+This module wraps the exchange's raw HTTP API. It handles authentication, request signing, and response/error classification.
+
+### Factory Function
+
+```javascript
+const axios = require('axios');
+const config = require('../../modules/configReader');
+
+module.exports = function() {
+  let WEB_BASE; // API base URL
+  let config_apiKey;
+  let config_secretKey;
+  let config_tradePwd;
+  let log;
+
+  const EXCHANGE_API = {
+    setConfig(apiServer, apiKey, secretKey, tradePwd, logger, publicOnly) {
+      WEB_BASE = apiServer;
+      config_apiKey = apiKey;
+      config_secretKey = secretKey;
+      config_tradePwd = tradePwd;
+      log = logger;
+    },
+
+    // ... methods below
+  };
+
+  return EXCHANGE_API;
+};
+
+module.exports.axios = axios; // Exported for mock-adapter in tests
+```
+
+### `handleResponse()` — Response Classification
+
+This is the most critical method. It classifies every HTTP response into:
+
+- **Temporary error** → `reject()` (triggers retry in protectedRequest/publicRequest)
+- **Final error** → `resolve()` with error data (caller decides what to do)
+- **Success** → `resolve()` with parsed data
+
+```javascript
+handleResponse(responseOrError, resolve, reject, queryString, url) {
+  const httpCode = responseOrError?.status || responseOrError?.response?.status;
+  const httpMessage = responseOrError?.statusText || responseOrError?.response?.statusText;
+  const data = responseOrError?.data || responseOrError?.response?.data;
+
+  const reqParameters = queryString || '{ No parameters }';
+
+  // Determine success and exchange-specific error
+  const success = httpCode === 200 && data?.code === '200000'; // Exchange-specific
+  const exchangeError = getExchangeError(data); // Extract error code + message
+
+  // Build error description from {exchange}_errors.js
+  const error = buildErrorMessage(httpCode, exchangeError);
+
+  if (success) {
+    resolve(data.data || data);
+  } else if (error.isTemporary) {
+    // 5xx, 429, timeouts — reject for retry
+    log.warn(`Request to ${url} with data ${reqParameters} failed. ${error.description}, details: ${httpCode} ${httpMessage}, [${exchangeError.code}] ${exchangeError.msg}. Rejecting…`);
+    reject(error);
+  } else {
+    // 4xx, business errors — resolve with error info for caller
+    log.warn(`Request to ${url} with data ${reqParameters} failed. ${error.description}, details: ${httpCode} ${httpMessage}, [${exchangeError.code}] ${exchangeError.msg}. Resolving…`);
+    resolve({
+      // Include exchange error info for the caller
+      exchangeErrorInfo: exchangeError,
+    });
+  }
+},
+```
+
+**Error message quality rules:**
+
+- Include HTTP code AND message: `401 Unauthorized`
+- Include exchange error code AND message: `[400004] KC-API-PASSPHRASE error`
+- No double spacing, no double dots, no missing codes
+- Distinguish between "Rejecting" (temporary, will retry) and "Resolving" (final, caller handles)
+
+### `publicRequest()` and `protectedRequest()`
+
+```javascript
+publicRequest(type, path, params) {
+  const url = `${WEB_BASE}${path}`;
+  return new Promise((resolve, reject) => {
+    const config = {
+      method: type,
+      url,
+      params,
+      headers: { 'Content-Type': 'application/json' },
+      timeout: 10000,
+    };
+
+    axios(config)
+        .then((response) => EXCHANGE_API.handleResponse(response, resolve, reject, JSON.stringify(params), url))
+        .catch((error) => EXCHANGE_API.handleResponse(error, resolve, reject, JSON.stringify(params), url));
+  });
+},
+
+protectedRequest(type, path, data) {
+  const url = `${WEB_BASE}${path}`;
+  const timestamp = Date.now();
+
+  // Build signature (exchange-specific: HMAC-SHA256, Ed25519, etc.)
+  const signature = buildSignature(timestamp, type, path, data, config_secretKey);
+
+  return new Promise((resolve, reject) => {
+    const config = {
+      method: type,
+      url,
+      data,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-KEY': config_apiKey,
+        'X-API-SIGN': signature,
+        'X-API-TIMESTAMP': timestamp,
+        // Exchange-specific headers...
+      },
+      timeout: 10000,
+    };
+
+    axios(config)
+        .then((response) => EXCHANGE_API.handleResponse(response, resolve, reject, JSON.stringify(data), url))
+        .catch((error) => EXCHANGE_API.handleResponse(error, resolve, reject, JSON.stringify(data), url));
+  });
+},
+```
+
+### Exchange-Specific API Methods
+
+Implement low-level methods that map directly to exchange API endpoints. Names can differ from the bot's interface:
+
+```javascript
+// Required methods (names are free-form, matched in trader_{exchange}.js)
+getBalances(params) { ... }          // Account balances
+getOrders(pair, status) { ... }      // Open/closed orders
+getOrder(orderId) { ... }            // Single order details
+addOrder(params) { ... }             // Place an order
+cancelOrder(orderId) { ... }         // Cancel an order
+cancelAllOrders(pair) { ... }        // Cancel all orders
+ticker(pair) { ... }                 // 24h market ticker
+orderBook(pair, limit) { ... }       // Order book depth
+markets() { ... }                    // All trading pairs info
+currencies() { ... }                 // All currencies info
+getTradesHistory(pair) { ... }       // Recent trades
+getDepositAddress(coin) { ... }      // Deposit address
+getFees(pair) { ... }                // Trading fees
+
+// Optional methods
+getAccounts() { ... }                // Account info
+transferFunds(params) { ... }        // Internal transfer
+getDepositHistory(params) { ... }    // Deposit history
+getWithdrawalHistory(params) { ... } // Withdrawal history
+addWithdrawal(params) { ... }        // Create withdrawal
+getVolume() { ... }                  // Account trading volume
+getCandlesHistory()                  // Candles data
+```
+
+**JSDoc for each method must include a link to the exchange API documentation:**
+
+```javascript
+/**
+ * Get account balances
+ * https://docs.exchange.com/api/v1/account/balances
+ * @param {object} params
+ * @returns {Promise<object>}
+ */
+getBalances(params) { ... }
+```
+
+---
+
+## Step 2: Error Descriptions File
+
+**File**: `trade/api/{exchange}_errors.js`
+
+If the exchange provides clear error codes, create a separate error descriptions file:
+
+```javascript
+const httpErrorCodeDescriptions = {
+  4: { description: 'Client error' },
+  400: { description: 'Bad request' },
+  401: { description: 'Invalid API Key' },
+  403: { description: 'Forbidden' },
+  404: { description: 'Not found' },
+  429: { description: 'Rate limit exceeded', isTemporary: true },
+  5: { description: 'Server error', isTemporary: true },
+  502: { description: 'Bad gateway', isTemporary: true },
+  503: { description: 'Service unavailable', isTemporary: true },
+};
+
+const exchangeErrorCodeDescriptions = {
+  '400001': { description: 'Insufficient balance' },
+  '400002': { description: 'Order does not exist' },
+  '400003': { description: 'Invalid parameter' },
+  '400004': { description: 'API key passphrase error' },
+  '429000': { description: 'Too many requests', isTemporary: true },
+  // ... all exchange-specific codes
+};
+
+module.exports = {
+  httpErrorCodeDescriptions,
+  exchangeErrorCodeDescriptions,
+};
+```
+
+**Key rules:**
+
+- `isTemporary: true` → `handleResponse` will `reject()` (retry via axios retry)
+- Without `isTemporary` → `handleResponse` will `resolve()` with error info (caller handles)
+- Map both HTTP codes (4xx, 5xx) and exchange-specific numeric/string codes
+- Use generic catch-alls: key `4` matches any 4xx, key `5` matches any 5xx
+
+---
+
+## Step 3: Trader Adapter
+
+**File**: `trade/trader_{exchange}.js`
+
+This is the bot-universal interface. It converts between the bot's standard method signatures/return shapes and the exchange-specific API.
+
+### Factory Function Signature (STRICT)
+
+```javascript
+const config = require('../modules/configReader');
+const ExchangeApi = require('./api/{exchange}_api');
+
+module.exports = (
+    apiKey,
+    secretKey,
+    pwd,
+    log,
+    publicOnly = false,
+    loadMarket = true,
+    useSocket = false,
+    useSocketPull = false,
+    accountNo = 0,
+    coin1 = config.coin1,
+    coin2 = config.coin2,
+) => {
+  const exchangeApiClient = ExchangeApi();
+  exchangeApiClient.setConfig(apiServer, apiKey, secretKey, pwd, log, publicOnly);
+
+  // Load markets on init
+  if (loadMarket) {
+    getMarkets();
+    if (!publicOnly) {
+      getCurrencies(); // Only if auth endpoints needed
+    }
+  }
+
+  // Return the public interface object
+  return {
+    get markets() { ... },
+    get currencies() { ... },
+    getMarkets,
+    getCurrencies,
+    marketInfo,
+    currencyInfo,
+    features,
+    getBalances,
+    getOpenOrders,
+    getOrderDetails,
+    placeOrder,
+    cancelOrder,
+    cancelAllOrders,
+    getRates,
+    getOrderBook,
+    getTradesHistory,
+    getCandlesHistory,
+    getDepositAddress,
+    getFees,
+    getAccount,
+    transfer,
+    withdraw,
+    getWithdrawalById,
+    processHistoryRecords,
+  };
+};
+```
+
+### Shared Module-Level State
+
+Markets and currencies are cached on `module.exports` for cross-instance sharing:
+
+```javascript
+module.exports.exchangeMarkets = {};       // Cached market data
+module.exports.exchangeCurrencies = {};    // Cached currency data
+module.exports.gettingMarkets = false;     // Guard against concurrent fetches
+module.exports.gettingCurrencies = false;
+```
+
+### Required Methods (Names Are STRICT)
+
+Every method below MUST exist and return data in the [standardized shapes](#return-shape-reference).
+
+#### `features(pair?)`
+
+Returns exchange capability flags. The bot checks these to decide what features to enable:
+
+```javascript
+function features(pair) {
+  return {
+    getMarkets: true,
+    getCurrencies: true,
+    supportCoinNetworks: true,          // Currencies include network info
+    placeMarketOrder: true,             // Exchange supports market orders
+    allowAmountForMarketBuy: true,      // Market buy can use base amount
+    allowAmountForMarketSell: true,     // Market sell can use base amount
+    amountForMarketOrderNecessary: false, // Market order REQUIRES amount (not quote)
+    getDepositAddress: true,
+    createDepositAddressWithWebsiteOnly: false,
+    selfTradeProhibited: true,          // Exchange prevents self-trade
+    getTradingFees: true,
+    getAccountTradeVolume: false,
+    getFundHistory: true,
+    getFundHistoryImplemented: true,
+    getWithdrawalById: true,
+    supportTransferBetweenAccounts: true,
+    accountTypes: ['spot', 'funding'],  // Available account types
+    tradingAccountType: 'spot',         // Which account is used for trading
+    orderNumberLimit: 200,              // Max open orders per pair
+    apiProcessingDelayMs: 10,           // Delay after order placement for API consistency
+    isDemo: false,                      // Demo/testnet account
+    // Socket features (only if WebSocket is implemented)
+    socketSupport: false,
+    socketPullSupport: false,
+    socketEnabled: useSocket,
+    // Data source for candle-based indicators
+    marketDataSource: 'candles',        // 'candles' or 'trades'
+  };
+}
+```
+
+#### `formatPairName(pair)` — Internal Helper
+
+Defined OUTSIDE the factory function (at file bottom), parses any pair format:
+
+```javascript
+/**
+ * Parses any pair format to standardized names
+ * @param {string} pair E.g. BTC/USDT, BTC-USDT, BTC_USDT, BTCUSDT
+ * @returns {{ coin1: string, coin2: string, pair: string, pairReadable: string, pairPlain: string, isParsed: boolean }}
+ */
+function formatPairName(pair) {
+  pair = pair?.toUpperCase();
+  // Split into coin1 and coin2 based on exchange's separator
+  // ...
+  return {
+    coin1,
+    coin2,
+    pair: coin1 + coin2,            // BTCUSDT (no separator)
+    pairReadable: `${coin1}/${coin2}`, // BTC/USDT
+    pairPlain: `${coin1}-${coin2}`,    // BTC-USDT (exchange's native format)
+    isParsed: true,
+  };
+}
+```
+
+#### `formatNetworkName(networkName)` — Internal Helper
+
+Maps exchange-specific network names to the bot's standard network codes using `helpers/networks.js`:
+
+```javascript
+const networks = require('../../helpers/networks');
+
+function formatNetworkName(networkName) {
+  // Exchange might call it 'ETHEREUM', 'ETH', 'erc20', 'ERC-20', etc.
+  // Map to standard: 'ERC20', 'BEP20', 'TRC20', 'SOL', etc.
+  const mapped = networks.findNetwork(networkName);
+  return mapped?.code || networkName;
+}
+```
+
+#### `getMarkets(pair?)`
+
+Fetches all trading pairs from the exchange. Stores results in `module.exports.exchangeMarkets`.
+
+```javascript
+async function getMarkets(pair) {
+  // Return cached if available and no specific pair requested
+  if (module.exports.exchangeMarkets && !pair) {
+    return module.exports.exchangeMarkets;
+  }
+
+  // Guard against concurrent fetches
+  if (module.exports.gettingMarkets) return;
+  module.exports.gettingMarkets = true;
+
+  try {
+    const data = await exchangeApiClient.markets();
+    if (!data) return undefined;
+
+    const result = {};
+    for (const market of data) {
+      const pairNames = formatPairName(`${market.baseAsset}/${market.quoteAsset}`);
+
+      result[pairNames.pairPlain] = {
+        pairReadable: pairNames.pairReadable,
+        pairPlain: pairNames.pairPlain,
+        coin1: pairNames.coin1,
+        coin2: pairNames.coin2,
+        coin1Decimals: getDecimalsFromStep(market.stepSize),
+        coin2Decimals: getDecimalsFromStep(market.tickSize),
+        coin1Precision: +market.stepSize,
+        coin2Precision: +market.tickSize,
+        coin1MinAmount: +market.minQty,
+        coin1MaxAmount: +market.maxQty,
+        coin2MinAmount: +market.minNotional,
+        coin2MaxAmount: null,
+        coin2MinPrice: +market.minPrice || null,
+        coin2MaxPrice: +market.maxPrice || null,
+        minTrade: +market.minNotional,
+        status: market.status === 'TRADING' ? 'ONLINE' : 'OFFLINE',
+      };
+    }
+
+    module.exports.exchangeMarkets = result;
+    log.log(`Received info about ${Object.keys(result).length} markets on ${config.exchangeName} exchange.`);
+
+    return result;
+  } catch (e) {
+    log.warn(`API request getMarkets() of trader_${config.exchange}.js module failed. ${e}`);
+    return undefined;
+  } finally {
+    module.exports.gettingMarkets = false;
+  }
+}
+```
+
+**Important**: Keys in `exchangeMarkets` should be `pairPlain` (exchange's native format like `BTC-USDT`), not `pairReadable`.
+
+#### `getCurrencies(coin?)`
+
+Similar to `getMarkets()` but for currencies. Stores results in `module.exports.exchangeCurrencies`. Must include:
+
+- Basic info: `symbol`, `name`, `status`, `decimals`, `precision`
+- Network info (if exchange provides): `networks` object with `{ withdrawalFee, minWithdrawal, confirmations, status, chainName }`
+- Use `formatNetworkName()` for network keys
+
+#### `marketInfo(pair)` and `currencyInfo(coin)`
+
+Return locally cached info for a specific pair/currency:
+
+```javascript
+function marketInfo(pair) {
+  const pairNames = formatPairName(pair);
+  return module.exports.exchangeMarkets?.[pairNames.pairPlain];
+}
+```
+
+#### `getBalances(nonzero = true, accountType)`
+
+Returns array of balance objects. Each method has **two separate try-catch blocks**: one for the API request, one for data processing.
+
+```javascript
+async function getBalances(nonzero = true, accountType) {
+  const paramString = `nonzero: ${nonzero}, accountType: ${accountType}`;
+
+  let data;
+  try {
+    data = await exchangeApiClient.getBalances({ type: accountType || 'trade' });
+  } catch (e) {
+    log.warn(`API request getBalances(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
+    return undefined;
+  }
+
+  try {
+    const result = [];
+    for (const balance of data) {
+      const free = +balance.available;
+      const freezed = +balance.frozen;
+      const total = free + freezed;
+      if (nonzero && total === 0) continue;
+
+      result.push({ code: balance.currency, free, freezed, total });
+    }
+    return result;
+  } catch (e) {
+    log.warn(`Error while processing getBalances(${paramString}) response: ${e}`);
+    return undefined;
+  }
+}
+```
+
+**Critical**: In case of ANY error (API or processing), return `undefined`. This eliminates false results. If the method returns data, it must accurately reflect exchange state.
+
+**Critical**: Code in `catch()` blocks must be reliable and never fail. No sensitive operations in catch blocks.
+
+#### `getOpenOrders(pair)`
+
+If the exchange paginates results, implement a private `getOpenOrdersPage()` helper and call it in a loop.
+
+Return array of order objects with statuses: `new` or `part_filled` (never `filled` — these are open orders).
+
+#### `getOrderDetails(orderId, pair)`
+
+Returns detailed info about a single order. Important for fill verification.
+
+Statuses: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
+
+- API error (500, timeout) → return `undefined`
+- Order not found → return `{ status: 'unknown' }`
+- Wrong orderId format → return `{ status: 'unknown' }` or `undefined`
+- Order found → return full details with correct status
+
+#### `placeOrder(side, pair, price, coin1Amount, limit = 1, coin2Amount)`
+
+The most complex method. Must handle 10 order variants:
+
+1. **Limit buy** with `coin1Amount` (base amount)
+2. **Limit buy** with `coin2Amount` (quote amount)
+3. **Limit sell** with `coin1Amount`
+4. **Limit sell** with `coin2Amount`
+5. **Limit buy** at price that fills immediately
+6. **Limit sell** at price that fills immediately
+7. **Market buy** with `coin1Amount`
+8. **Market buy** with `coin2Amount`
+9. **Market sell** with `coin1Amount`
+10. **Market sell** with `coin2Amount`
+
+**Pre-validation checklist:**
+
+```javascript
+async function placeOrder(side, pair, price, coin1Amount, limit = 1, coin2Amount) {
+  const paramString = `side: ${side}, pair: ${pair}, price: ${price}, coin1Amount: ${coin1Amount}, limit: ${limit}, coin2Amount: ${coin2Amount}`;
+
+  // 1. Check market info exists
+  const marketData = marketInfo(pair);
+  if (!marketData) {
+    log.warn(`Unable to place order on ${pair}: no market info.`);
+    return { message: `No market info for ${pair}` };
+  }
+
+  // 2. Calculate amount/quote with correct decimals
+  // 3. Validate min/max amounts
+  // 4. Validate min/max price
+  // 5. Build exchange-specific order params
+
+  try {
+    const data = await exchangeApiClient.addOrder(orderParams);
+    // ...
+    if (data?.orderId) {
+      return { orderId: String(data.orderId), message: undefined };
+    } else {
+      return { orderId: undefined, message: data?.message || 'Unknown error' };
+    }
+  } catch (e) {
+    log.warn(`API request placeOrder(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
+    return undefined;
+  }
+}
+```
+
+**If placing fails after pre-checks** (invalid params, insufficient min amount): log and return `{ message: '...' }` with `orderId: undefined`.
+
+#### `cancelOrder(orderId, side, pair)`
+
+- Order cancelled → `true`
+- Order not found / already cancelled → `false`
+- Wrong orderId format → `false` or `undefined`
+- API error → `undefined`
+
+#### `cancelAllOrders(pair)`
+
+- Orders cancelled → `true`
+- No open orders → `true`
+- Pair doesn't exist → `false` or `undefined`
+
+#### `getRates(pair)`
+
+Returns 24h ticker. Pair doesn't exist → `undefined`.
+
+#### `getOrderBook(pair)`
+
+Returns `{ bids, asks }`. Bids sorted by price descending, asks ascending. If API allows, request 200 items with no grouping (plain order book).
+
+#### `getTradesHistory(pair)`
+
+Returns array sorted by timestamp ascending. If API allows, request 300 items.
+
+#### `getCandlesHistory(pair, timeframe, since, limit, excludeLast?)`
+
+Returns OHLCV candle data array.
+
+#### `getDepositAddress(coin)`
+
+Returns array of `{ network, address, memo? }`. Use `formatNetworkName()` for network names. Return addresses for all networks where deposits are enabled.
+
+#### `getFees(coinOrPair)`
+
+- If `coinOrPair` is a coin (e.g., BTC): return fees for all pairs where this coin is base
+- If `coinOrPair` is a pair: return fees for that pair
+- If neither provided: return fees for all pairs (if possible) or `undefined`
+- Returns `[{ pair, makerRate, takerRate }]`
+
+#### `transfer(coin, from, to, amount)`
+
+Internal account transfer (e.g., spot → funding). If `amount` not set, transfer full balance. Returns `{ success, errorMessage? }`.
+
+#### `withdraw(address, amount, coin, withdrawalFee, network)`
+
+External withdrawal. `withdrawalFee` is sent ON TOP of `amount`. Returns `{ success, id?, errorMessage? }`.
+
+#### `getDepositHistory(coin, limit)` and `getWithdrawalHistory(coin, limit)`
+
+Via `processHistoryRecords(target, coin, limit)`. Returns array of history records.
+
+#### `getWithdrawalById(id)`
+
+Single withdrawal record lookup.
+
+#### `getVolume()`
+
+Account's 24h trading volume. Returns `[{ updated, volume30days, volumeUnit }]`.
+
+#### `getAccount()`
+
+Account basic info.
+
+---
+
+## Step 4: Config & Registration
+
+### Create Config File
+
+Copy `config.default.jsonc` → `config.{exchange}_test.jsonc`:
+
+```jsonc
+{
+  "exchange": "Newexchange",  // Exchange name (capital first letter)
+  "pair": "BTC/USDT",
+  "apikey": "your-api-key",
+  "apisecret": "your-api-secret",
+  "apipassword": "",          // If exchange requires API passphrase
+  "api": {
+    "port": 1111,
+    "ip": "0.0.0.0",
+    "health_check": true,
+    "debug_info": true
+  }
+  // ...other settings
+}
+```
+
+### Register Exchange Name
+
+Add the exchange name to the `exchanges` array in `config.default.jsonc`:
+
+```jsonc
+"exchanges": [
+  // ... existing exchanges
+  "Newexchange"
+]
+```
+
+### Trade Params Override (Optional)
+
+If an exchange needs different default parameters, create `trade/settings/tradeParams_{exchange}.js`. Otherwise, the bot copies `tradeParams_Default.js` automatically at startup.
+
+---
+
+## Step 5: Testing Spot REST Connector
+
+### Testing Tools
+
+1. **Logging**: `console.log()` in API methods (temporary, remove before PR)
+2. **Bot commands**: `/balances`, `/orders`, `/rates`, `/buy`, `/sell`, etc.
+3. **Manual test runner**: Set `"dev": true` in config, use `trade/tests/manual.test.js`:
+   - Uncomment the desired test block (e.g., `test_spot()`)
+   - Add method calls inside the function
+   - Run: `node app.js {config_name}`
+   - Methods execute a few seconds after bot starts
+
+```javascript
+// In trade/tests/manual.test.js — test_spot() function
+console.log(await traderapi.cancelOrder('5d13f3e8-dcb3-4a6d-88c1-16cf6e8d8179', undefined, 'DOGE/USDT'));
+console.log(await traderapi.getOpenOrders('BTC/USDT'));
+console.log(await traderapi.placeOrder('buy', 'BTC/USDT', 30000, 0.001, 1));
+```
+
+### Start Testing
+
+Run: `node app.js {config_name}` (or `npm run start:config -- {config_name}`)
+
+On successful startup, you should see:
+
+1. Connected to MongoDB
+2. Received info about N markets on Exchange
+3. Received info about N currencies on Exchange (if applicable)
+4. API server listening
+5. Bot started notification
+
+### Testing `handleResponse()` — Request Processing
+
+Add temporary logging after the request parameters line in `{exchange}_api.js`:
+
+```javascript
+console.log(`Request to ${url} returned ${httpCode} ${httpMessage}`);
+console.log(`success is ${success}`);
+console.log(`exchangeError is ${JSON.stringify(exchangeError)}`);
+console.log(`error is ${JSON.stringify(error)}`);
+// console.log(`data is ${data}`); // Only for failed requests — too verbose for success
+```
+
+#### Test: Server Timeout
+
+Set `timeout: 1` instead of `timeout: 10000` in `publicRequest()`.
+
+**Expected**: Request rejected, good-looking error message with `AxiosError: timeout of 1ms exceeded`.
+
+#### Test: Invalid API Keys
+
+Use wrong API keys in config, send `/balances`.
+
+**Expected**:
+
+- Request resolved (not rejected — auth errors are final)
+- Error message includes HTTP code, message, exchange error code and message
+- Example: `401 Unauthorized, [400004] KC-API-PASSPHRASE error`
+
+**Bad output examples** (fix if you see these):
+
+- Missing HTTP code: `Unauthorized, [400004] ...`
+- Double spacing: `401 Unauthorized,  [400004] ...`
+- Double dot: `...error.. Rejecting…`
+- Not enough details: `...details: 400004. Rejecting…`
+
+#### Test: Resolved Errors
+
+When a request errors with a final state, it must resolve (not reject) with error info:
+
+```javascript
+// Test: cancel a non-existent order
+console.log(await traderapi.cancelOrder('non-existent-id', undefined, 'DOGE/USDT'));
+// Should return false (not throw), with good log message
+```
+
+### Testing Individual Methods
+
+For each method below, check:
+
+1. The connected API method and its documentation
+2. Log BOTH raw request results AND processed results
+3. Compare with exchange UI
+4. All numbers stored as numbers, not strings
+
+#### `getMarkets(pair)`
+
+```javascript
+// Add logging inside getMarkets():
+if (market.symbol === 'KCS-BTC') {
+  console.log('Plain data:', market);
+  console.log(`${market.symbol} -> ${JSON.stringify(pairNames)}`);
+  console.log('Formatted data:', result[pairNames.pairPlain]);
+}
+```
+
+**Verify:**
+
+- All fields present: `pairReadable`, `pairPlain`, `coin1`, `coin2`, `coin1Decimals`, `coin2Decimals`, `coin1MinAmount`, `coin1MaxAmount`, `status`, etc.
+- `coin1Decimals`, `coin2Decimals` match exchange UI
+- `formatPairName()` produces correct results
+- Market count matches exchange documentation
+- Keys in `exchangeMarkets` are `pairPlain`, not `pairReadable`
+
+#### `getCurrencies(coin?)`
+
+```javascript
+// Add logging:
+console.log(`${chainName} -> ${formatNetworkName(chainName)}`);
+if (currency.currency === 'USDT') {
+  console.log('Plain data:', currency);
+  console.log('Formatted data:', result[currency.currency]);
+}
+```
+
+**Verify:**
+
+- All fields present: `symbol`, `name`, `status`, `decimals`, `precision`, `networks`
+- `formatNetworkName()` maps all exchange networks to standard codes (ERC20, BEP20, TRC20, SOL, etc.)
+- Network objects include: `status`, `depositStatus`, `withdrawalStatus`, `confirmations`, `withdrawalFee`, `chainName`
+- If currencies use auth endpoint, only fetch when `publicOnly === false`
+- Currency count matches exchange documentation
+- Network info matches what exchange UI shows for deposits/withdrawals
+
+#### `marketInfo(pair)` and `currencyInfo(coin)`
+
+Quick check: return cached data for a specific pair/coin.
+
+#### `features()`
+
+Verify all flags match exchange API documentation and capabilities.
+
+#### `getBalances(nonzero, accountType)`
+
+Test via logging, `/balances` command, and direct execution.
+
+**Verify**: Each crypto has `code`, `free`, `freezed`, `total`. Compare with exchange UI.
+
+#### `getOpenOrders(pair)`
+
+**Expected results:**
+
+- Pair doesn't exist → `undefined`
+- No open orders → empty array `[]`
+- Has open orders → array with: `orderId` (string), `symbol`, `symbolPlain`, `price` (number), `side`, `type`, `timestamp` (ms), `amount` (number), `amountExecuted` (number), `amountLeft` (number), `status` (`new` or `part_filled`)
+
+**Test `part_filled`**: Place a sell order in spread, then a buy at same price with lower amount:
+
+```javascript
+const testPrice = 0.0002162;
+const testMarket = 'KCS/BTC';
+await traderapi.placeOrder('sell', testMarket, testPrice, 0.2);
+await traderapi.placeOrder('buy', testMarket, testPrice, 0.1);
+await traderapi.getOpenOrders(testMarket);
+// The sell order should now be part_filled
+```
+
+#### `getOrderDetails(orderId, pair)`
+
+Test ALL statuses: `unknown`, `new`, `filled`, `part_filled`, `cancelled`.
+
+Test `filled` with both limit and market orders (buy and sell).
+
+**Expected:**
+
+- API error → `undefined`
+- Order not found → `{ status: 'unknown' }`
+- Wrong orderId format → `{ status: 'unknown' }` or `undefined`
+- Order found → `orderId`, `pairReadable`, `pairPlain`, `price`, `side`, `type`, `timestamp`, `amount`, `volume`, `amountExecuted`, `volumeExecuted`, `status`
+
+#### `cancelOrder(orderId, side, pair)`
+
+- Exists and cancelled → `true`
+- Not found / already cancelled → `false`
+- Wrong format → `false` or `undefined`
+
+#### `cancelAllOrders(pair)`
+
+- Pair doesn't exist → `false` or `undefined`
+- No open orders → `true`
+- Orders cancelled → `true`
+
+#### `getRates(pair)`
+
+- Pair doesn't exist → `undefined`
+- Otherwise → `{ ask, bid, last, volume, volumeInCoin2, high, low }` (all numbers)
+
+#### `placeOrder(side, pair, price, coin1Amount, limit, coin2Amount)`
+
+Test all 10 order types listed in [Step 3: placeOrder](#placeorderside-pair-price-coin1amount-limit--1-coin2amount).
+
+**Additional tests:**
+
+- Insufficient balance
+- Wrong parameters
+- Small-price pairs (price < 10⁻⁸)
+- Amount below exchange minimum
+- Volume below exchange minimum
+- Precision higher than allowed
+
+Check the `/balances` after each order to verify `free`, `freezed`, `total` match expectations.
+
+**Verify**: Log messages and reply messages to admins are consistent and good-looking.
+
+#### `getTradesHistory(pair)`
+
+- Pair doesn't exist → `undefined`
+- Otherwise → array of `{ coin1Amount, price, coin2Amount, date, type, tradeId? }` sorted by timestamp ascending. 300 items if API allows.
+
+#### `getOrderBook(pair)`
+
+- Pair doesn't exist → `undefined`
+- Otherwise → `{ bids: [{ amount, price, count, type }], asks: [...] }`. Bids desc, asks asc. 200 items if API allows. No order grouping.
+
+#### `getDepositAddress(coin)`
+
+- Returns `[{ network, address, memo? }]`
+- `network` formatted via `formatNetworkName()`
+- Returns all networks where deposits are enabled
+- Test multi-network coins (USDT) and single-network (DASH, ADM)
+- Error → `{ success: false, message }` or `undefined`
+
+#### `transfer(coin, from, to, amount)`
+
+- Check `/balances full` before and after
+- If no amount specified, transfers full balance
+- Error → `{ success: false, errorMessage }`
+
+#### `withdraw(address, amount, coin, withdrawalFee, network)`
+
+- Withdraw to your own account and verify arrival
+- `withdrawalFee` is ON TOP of `amount`
+- Check via `/show withdrawals` and `/balances full`
+- Success → `{ success: true, id, currency, amount, address, withdrawalFee, ... }`
+- Error → `{ success: false, errorMessage }`
+
+#### `getDepositHistory(coin, limit)` and `getWithdrawalHistory(coin, limit)`
+
+Test via `/show deposits` and `/show withdrawals`. Error → `{ success: false, errorMessage }`.
+
+#### `getWithdrawalById(id)`
+
+Test via `/show withdrawal {ID}`.
+
+#### `getFees(coinOrPair)`
+
+- Works for both coins and pairs
+- For a coin → fees for all pairs where coin is base
+- Neither coin nor pair → fees for all pairs or `undefined`
+- Returns `[{ pair, makerRate, takerRate }]`
+- Non-existent coin/pair → empty array or `undefined`
+
+#### `getVolume()`
+
+Returns `[{ updated, volume30days, volumeUnit }]`. Error → `undefined`.
+
+---
+
+## Step 6: WebSocket Connector (Optional)
+
+WebSocket extends the REST connector with real-time data. Three priority levels:
+
+1. **WS Subscription** (highest) — real-time push
+2. **WS Pull** — request-response over WS
+3. **REST** (lowest) — traditional HTTP polling
+
+### File Structure
+
+```text
+trade/api/websocket/
+├── websocketApi.js                       # Generic WS base class (DO NOT MODIFY)
+├── {exchange}WebsocketApi.js             # Public WS (market data)
+├── {exchange}WebsocketPrivateApi.js      # Private WS (account data)
+└── {exchange}WebsocketPullApi.js         # WS pull (request-response)
+```
+
+### Architecture
+
+- **Base class** `WebSocketApi` handles: connection lifecycle, heartbeat, reconnection, and a `store` with data channels (`depth`, `trades`, `balance`, `orders`, `rates`) and validity tracking
+- Exchange implementations extend `WebSocketApi` and override: `subscribe()`, `initEvents()`, `removeEvents()`, `auth()`, `fetchInitialData()`
+
+### Trader Adapter Modifications
+
+When WS is implemented, modify `trader_{exchange}.js`:
+
+1. Add to `features()`:
+
+```javascript
+socketSupport: true,
+socketPullSupport: true,
+socketEnabled: useSocket,
+```
+
+2. Add WS helper methods:
+
+```javascript
+isPublicWsEnabled(dataName, pairObj) { ... }
+isPrivateWsEnabled(dataName, pairObj) { ... }
+wsPublicPullEnabled(pullMethod) { ... }
+wsPrivatePullEnabled(pullMethod) { ... }
+```
+
+3. Amend data methods to prefer WS over REST:
+
+```javascript
+async function getRates(pair) {
+  // Priority: WS subscription → WS pull → REST
+  if (isPublicWsEnabled('rates', pairObj)) {
+    return wsApiClient.store.rates[pairPlain];
+  }
+  if (wsPublicPullEnabled('getRates')) {
+    return wsApiClient.pullRates(pairPlain);
+  }
+  // Fallback to REST
+  return getRestRates(pair);
+}
+```
+
+### Methods to Implement
+
+#### Public WS
+
+| Method | WS Subscription | WS Pull |
+| -------- | ---------------- | --------- |
+| `getRates(pair)` | Yes | Yes |
+| `getOrderBook(pair)` | Yes (subscribe to diffs with checksum, not full book) | Yes |
+| `getTradesHistory(pair)` | Yes (subscribe to new trades, fill history via pull/REST) | Yes |
+
+**Order book** is usually maintained via differential updates:
+
+- Initially fill via WS pull or REST snapshot
+- Subscribe to add/remove/amend events
+- Verify integrity via checksum (if exchange provides)
+- Re-subscribe on checksum mismatch
+
+#### Private WS
+
+| Method | WS Subscription | WS Pull |
+| -------- | ---------------- | --------- |
+| `getBalances` | Yes (subscribe to balance changes) | Yes |
+| `getOpenOrders` | Yes (subscribe to order changes) | Yes |
+| `getOrderDetails` | — | Yes (handler) |
+| `cancelOrder` | — | Yes (handler) |
+| `placeOrder` | — | Yes (handler) |
+
+---
+
+## Step 7: Perpetual/Futures Connector (Optional)
+
+### Architecture
+
+```text
+modules/perpetualApi.js              # Singleton factory (loads exchange-specific impl)
+trade/api/contract/
+├── perpetualApi.js                  # Abstract base class (DO NOT MODIFY)
+└── {exchange}PerpetualApi.js        # Exchange-specific implementation
+```
+
+### Key Differences from Spot
+
+- Pair naming: `BTCUSDT` (perpetual) vs `BTC/USDT` (spot)
+- `buy/sell` ≡ `long/short` in context
+- Set `isDemoAccount: true` in config for testing before live
+- Most trade modules DO NOT work with perpetual (only `mm_trader` and `mm_orderbook_builder`)
+
+### Implementation Pattern
+
+```javascript
+const PerpetualApi = require('./perpetualApi');
+
+class ExchangePerpetualApi extends PerpetualApi {
+  constructor(params) {
+    super(params);
+    // Create spotApi (plain API client) and traderApi (trader adapter)
+    this.spotApi = ExchangeApiClient();
+    this.traderApi = TraderFactory(params.apiKey, params.secretKey, ...);
+  }
+
+  // Override abstract methods...
+}
+```
+
+Reuse spot methods where possible. If `getOrderBook()` is 70% shared between spot and perpetual, modify the spot method to be universal rather than duplicating.
+
+### Methods to Implement
+
+| Method | Notes |
+| -------- | ------- |
+| `features()` | Perpetual-specific capabilities |
+| `formatPairName(pair)` | Returns `pairPerpetual: 'BTCUSDT'` |
+| `getBalances(nonzero, accountType)` | Futures account balances |
+| `getFees(coinOrPair, category)` | May differ from spot |
+| `getInstruments(symbol, forceUpdate)` | Like spot's `getMarkets()` |
+| `instrumentInfo(symbol)` | Like spot's `marketInfo()` |
+| `getOrderBook(symbol, limit)` | Often reuses spot implementation |
+| `getTickerInfo(symbol)` | Includes perpetual-specific: open interest, mark price |
+| `getPublicTradeHistory(symbol, limit)` | Recent trades |
+| `getOpenInterest(intervalTime)` | Open interest data |
+| `getLongShortRatio(intervalTime)` | Long/short ratio |
+| `getRiskLimit(symbol)` | Max leverage & caps |
+| `placeOrder(symbol, side, type, qty, price, reduceOnly, ...)` | Long/short with leverage |
+| `cancelOrder(orderId, symbol, side)` | Cancel perpetual order |
+| `cancelAllOrders(symbol, side)` | Cancel all perpetual orders |
+| `getOpenOrders(symbol)` | Unfilled/partially filled |
+| `getOrderDetails(orderId)` | Order info |
+| `getPositions(symbol)` | Open positions with PnL |
+| `closePosition(symbol, price?)` | Close at limit or market |
+| `setLeverage(symbol, leverage)` | Set leverage |
+| `switchMarginMode(symbol, mode, leverage)` | `isolated` or `cross` |
+| `switchPositionMode(symbol, mode)` | `oneway` or `hedge` |
+| `setTakeProfitStopLoss(symbol, tp, sl, ...)` | TP/SL management |
+
+### Modules Compatibility with Perpetual
+
+| Module | Perpetual | Notes |
+| -------- | ----------- | ------- |
+| `mm_trader` | Yes | Single account only |
+| `mm_orderbook_builder` | Yes | — |
+| All other `mm_*` modules | **No** | Return error: "The feature {name} is not available for perpetual contract trading." |
+| Two-key trading | **No** | `useSecondAccount = traderapi2 && !isPerpetual` |
+| `cs_manager` | **No** | — |
+
+---
+
+## Step 8: Automated Tests
+
+**File**: `trade/tests/trader_{exchange}.test.js`
+
+Use Jest with `axios-mock-adapter` to test without real API calls:
+
+```javascript
+const MockAdapter = require('axios-mock-adapter');
+const exchangeApi = require('../api/{exchange}_api');
+const { axios } = exchangeApi;
+
+const config = require('../../modules/configReader');
+const TraderFactory = require('../trader_' + config.exchange);
+
+let mock;
+let traderapi;
+
+beforeAll(async () => {
+  mock = new MockAdapter(axios);
+  traderapi = TraderFactory(
+      config.apikey, config.apisecret, config.apipassword,
+      console, false, true, false, false, 0, config.coin1, config.coin2,
+  );
+
+  // Mock getMarkets response
+  mock.onGet('/api/v2/symbols').reply(200, require('./trader_{exchange}.mock').marketsResponse);
+  await traderapi.getMarkets();
+});
+
+afterAll(() => mock.restore());
+
+describe('trader_{exchange}', () => {
+  test('getBalances returns correct shape', async () => {
+    mock.onGet('/api/v1/accounts').reply(200, mockBalancesResponse);
+    const balances = await traderapi.getBalances(false);
+    expect(balances).toBeInstanceOf(Array);
+    expect(balances[0]).toHaveProperty('code');
+    expect(balances[0]).toHaveProperty('free');
+    expect(typeof balances[0].free).toBe('number');
+  });
+
+  test('placeOrder returns orderId', async () => {
+    mock.onPost('/api/v1/orders').reply(200, { code: '200000', data: { orderId: '123' } });
+    const result = await traderapi.placeOrder('buy', 'BTC/USDT', 30000, 0.001, 1);
+    expect(result).toHaveProperty('orderId', '123');
+  });
+
+  // ... test each method
+});
+```
+
+**Mock data file**: `trade/tests/trader_{exchange}.mock.js` — export mock API response objects.
+
+---
+
+## Step 9: MM Simulation Testing
+
+After all individual methods pass, run a full market-making simulation:
+
+1. **Choose a trading pair with rare trading activity** (to control the environment)
+2. **Enable features**: `t` (trader, in-spread strategy, small amounts), `ob`, `ag`, `ld`, `liq`
+3. **Run the bot** and carefully monitor:
+   - Logs for errors, warnings, unexpected behavior
+   - Trading pair's order book, trade history, and chart on exchange website
+   - Bot replies to commands: `/balances`, `/orders`, `/rates`, `/stats`
+4. **Critical check**: There must be NO `unk` (unknown) orders when you run `/orders`. If there are, something is wrong with order tracking.
+5. **Watch for**:
+   - Orders placed at correct prices and amounts
+   - Orders cancelled properly when modules rotate
+   - Balances tracked accurately
+   - No duplicate orders
+   - Correct spread maintenance
+
+---
+
+## Coding Guidelines
+
+### Mandatory Connector Quality Rules
+
+These rules are mandatory for every new connector and connector refactor.
+
+1. **Strict JSDoc and typedef usage**
+
+Add detailed JSDoc for all public methods in both `trade/api/{exchange}_api.js` and `trade/trader_{exchange}.js`. Use typedef imports from `types/*.d.js` in the same style as `trade/trader_binance.js`.
+
+2. **Endpoint response types are required**
+
+Create exchange-specific endpoint response typedef files under `types/{exchange}/`, include realistic `@example` payloads, and apply those typedefs in API and trader files (avoid untyped endpoint payloads).
+
+3. **Direct API docs links in API method JSDoc**
+
+Every API method in `trade/api/{exchange}_api.js` must include a direct URL to the exact official endpoint documentation.
+
+4. **Describe enum values and parameter semantics in JSDoc**
+
+Do not leave enum-like parameters undocumented (for example, avoid bare `@param {0 | 1 | 2 | 3 | 4} typeTrade`). Always explain each meaningful value and usage constraints in JSDoc and in `types/{exchange}/*.d.js`.
+
+5. **No silent response-shape masking**
+
+Do not hide malformed payloads with permissive patterns like `response?.list || []`. Validate response shape explicitly and log/handle invalid payloads.
+
+6. **Use `marketInfo()` in candle normalization paths**
+
+In trader adapters, candle parsing must use `marketInfo()` metadata (decimals/precision), not ad-hoc market reloading.
+
+7. **Use exchange bulk cancellation endpoint**
+
+If exchange supports bulk order cancellation, `cancelAllOrders()` must use that endpoint as primary path.
+
+8. **Extract reusable helpers**
+
+Before introducing local helper logic, check `helpers/utils.js`. If helper can be reused across modules, add it to `helpers/utils.js` and use it from there.
+
+9. **Mandatory test evidence and reports**
+
+Provide detailed raw and normalized outputs for connector tests, explicitly cover `getOrderDetails` status normalization (`unknown`, `new`, `filled`, `part_filled`, `cancelled`), and save reports as separate files per mode: `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-mock) ... .md` for mock runs and `.ai-tasks/test-results/YYYY-MM-DD (TestXXX-live) ... .md` for live runs.
+
+10. **Exchange trade params file policy**
+
+`trade/settings/tradeParams_{exchange}.js` must contain a full copied object from `tradeParams_Default.js`. Do not re-export default trade params with `require('./tradeParams_Default')`.
+
+11. **Markdown lint compliance is mandatory**
+
+All Markdown documentation must pass markdownlint rules, including `MD022` (blanks around headings), `MD032` (blanks around lists), `MD007` (list indentation), `MD034` (no bare URLs), and `MD040` (fenced code language).
+
+12. **Use explicit exchange-prefixed typedef names**
+
+Avoid ambiguous `default` typedef names in `types/{exchange}/*.d.js`. Use human-readable exchange-prefixed names (for example, `DextradeSymbols`, `DextradeTicker`, `DextradeOrder`) and import the exact named typedef in API and trader files.
+
+13. **One-line description punctuation rule**
+
+For one-line parameter/property/list descriptions, do not use a trailing period if there is only one sentence. If there are two or more sentences, keep terminal periods after each sentence.
+
+### String Quoting
+
+- **Single quotes** everywhere: code, JSDoc, comments
+- Exception: separate `*.d.js` type definition files may use double quotes
+
+```javascript
+// ❌ WRONG
+/** @param {"delete" | "get" | "post"} method */
+/** @param {string} pair E.g. "BTC/USDT" */
+
+// ✅ CORRECT
+/** @param {'delete' | 'get' | 'post'} method */
+/** @param {string} pair E.g. BTC/USDT */
+
+// ✅ CORRECT — long strings should be quoted
+/** @param {string} orderId Example: 'a9625b04-fc66-4999-a876-543c3684d702' */
+```
+
+### Async/Await
+
+All methods in `trader_{exchange}.js` use `async/await`, **not** Promises.
+
+Exception: `getMarkets()` and `getCurrencies()` may still use Promise-based implementation, but `async/await` is preferred for new connectors.
+
+### Error Handling
+
+Every method has two separate try-catch blocks:
+
+```javascript
+async function someMethod(params) {
+  const paramString = `params: ${JSON.stringify(params)}`;
+
+  // Block 1: API request
+  let data;
+  try {
+    data = await exchangeApiClient.someEndpoint(params);
+  } catch (e) {
+    log.warn(`API request someMethod(${paramString}) of trader_${config.exchange}.js module failed. ${e}`);
+    return undefined;
+  }
+
+  // Block 2: Data processing
+  try {
+    // Process data...
+    return processedResult;
+  } catch (e) {
+    log.warn(`Error while processing someMethod(${paramString}) response: ${e}`);
+    return undefined;
+  }
+}
+```
+
+### Linter
+
+Always run `npm run lint` before submitting. Rules are in `eslint.config.js`.
+
+---
+
+## Return Shape Reference
+
+### Balances
+
+```javascript
+[{ code: 'BTC', free: 0.5, freezed: 0.1, total: 0.6 }]
+```
+
+### Open Orders
+
+```javascript
+[{
+  orderId: '12345',          // string
+  symbol: 'BTC/USDT',       // pairReadable
+  symbolPlain: 'BTC-USDT',  // pairPlain
+  price: 30000,             // number
+  side: 'buy',              // 'buy' | 'sell'
+  type: 'limit',            // 'limit' | 'market'
+  timestamp: 1701820952000, // ms unix
+  amount: 0.001,            // number, base amount
+  amountExecuted: 0,        // number
+  amountLeft: 0.001,        // number
+  status: 'new',            // 'new' | 'part_filled'
+  // Optional:
+  fee: 0.00001,             // number
+}]
+```
+
+### Order Details
+
+```javascript
+{
+  orderId: '12345',
+  pairReadable: 'BTC/USDT',
+  pairPlain: 'BTC-USDT',
+  price: 30000,              // number
+  side: 'buy',
+  type: 'limit',
+  timestamp: 1701820952000,  // ms unix
+  amount: 0.001,             // number
+  volume: 30,                // number, coin2 amount
+  amountExecuted: 0.001,     // number
+  volumeExecuted: 30,        // number
+  status: 'filled',          // 'unknown' | 'new' | 'filled' | 'part_filled' | 'cancelled'
+  // Optional:
+  totalFeeInCoin2: 0.03,     // number
+  updateTimestamp: 1701820960000,
+  tradesCount: 1,
+}
+```
+
+### Order Book
+
+```javascript
+{
+  bids: [{ amount: 0.5, price: 29999, count: 1, type: 'bid' }],   // desc by price
+  asks: [{ amount: 0.3, price: 30001, count: 1, type: 'ask' }],   // asc by price
+}
+```
+
+### Rates / Ticker
+
+```javascript
+{ ask: 30001, bid: 29999, last: 30000, volume: 1234.5, volumeInCoin2: 37035000, high: 30500, low: 29500 }
+```
+
+### Place Order
+
+```javascript
+{ orderId: '12345', message: undefined }          // Success
+{ orderId: undefined, message: 'Insufficient funds' }  // Pre-check failure
+undefined                                          // API error
+```
+
+### Trade History
+
+```javascript
+[{
+  coin1Amount: 0.001,        // number
+  price: 30000,              // number
+  coin2Amount: 30,           // number
+  date: 1701820952000,       // ms unix
+  type: 'buy',               // 'buy' | 'sell'
+  tradeId: 'abc123',         // string, optional
+}]
+// Sorted by timestamp ascending
+```
+
+### Fees
+
+```javascript
+[{ pair: 'BTC/USDT', makerRate: 0.001, takerRate: 0.001 }]
+```
+
+### Market Info
+
+```javascript
+{
+  pairReadable: 'BTC/USDT',
+  pairPlain: 'BTC-USDT',
+  coin1: 'BTC',
+  coin2: 'USDT',
+  coin1Decimals: 8,          // number of decimal places for base amount
+  coin2Decimals: 2,          // number of decimal places for quote price
+  coin1Precision: 0.00000001, // smallest step for base
+  coin2Precision: 0.01,       // smallest step for quote
+  coin1MinAmount: 0.00001,
+  coin1MaxAmount: 9000,
+  coin2MinAmount: 10,         // min notional / min quote
+  coin2MaxAmount: null,
+  coin2MinPrice: 0.01,
+  coin2MaxPrice: 1000000,
+  minTrade: 10,               // Legacy, duplicates coin2MinAmount or coin1MinAmount
+  status: 'ONLINE',           // 'ONLINE' | 'OFFLINE'
+}
+```
+
+### Currency Info
+
+```javascript
+{
+  symbol: 'USDT',
+  name: 'USDT',
+  status: 'ONLINE',
+  comment: undefined,
+  confirmations: 0,
+  withdrawalFee: undefined,    // May be per-network
+  minWithdrawal: undefined,
+  maxWithdrawal: undefined,
+  logoUrl: undefined,
+  exchangeAddress: undefined,
+  decimals: 8,
+  precision: 0.00000001,
+  minSize: undefined,
+  type: undefined,
+  networks: {
+    ERC20: {
+      withdrawalFee: 3.5,
+      minWithdrawal: 10,
+      confirmations: 12,
+      status: 'ONLINE',
+      chainName: 'ETH',       // Exchange's raw name
+      chainId: 'eth',         // Exchange's raw ID, if available
+      chainMappedCode: 'ERC20',     // From networks.js
+      chainMappedName: 'Ethereum',  // From networks.js
+    },
+    // ...more networks
+  },
+  defaultNetwork: undefined,
+}
+```
+
+### Deposit Address
+
+```javascript
+[{ network: 'ERC20', address: '0x...', memo: undefined }]
+// Or on error:
+{ success: false, message: 'No deposit address found' }
+```
+
+---
+
+## Terminology Reference
+
+| Term | Definition |
+| ------ | ----------- |
+| **pairReadable** | Human-readable pair format: `ADM/USDT` |
+| **pairPlain** | Exchange's native pair format: `ADM-USDT`, `ADM_USDT`, `ADMUSDT` |
+| **pairPerpetual** | Perpetual contract format: `ADMUSDT` (no separator) |
+| **coin1 / base** | First currency in pair (the asset being traded) |
+| **coin2 / quote** | Second currency in pair (the pricing currency) |
+| **bid** | Buy orders (below current price, green, left side of order book) |
+| **ask** | Sell orders (above current price, red, right side of order book) |
+| **decimals** | Number of decimal places. `decimals=4` → `0.0041` |
+| **precision** | Smallest unit derived from decimals. `decimals=4` → `precision=0.0001` |
+| **isTemporary** | Error that may succeed on retry (5xx, timeouts, rate limits) |
+| **publicOnly** | Create API instance without private endpoint initialization |
+| **loadMarket** | Whether to fetch market/currency lists on init (default: true) |
+| **reduceOnly** | Perpetual: order can only reduce position size, never increase |
+| **funding rate** | Perpetual: periodic fee exchanged between longs and shorts |
+| **open interest** | Perpetual: total contracts currently held on the platform |
+| **margin mode** | Perpetual: `isolated` (limited loss) or `cross` (full balance at risk) |
+| **position mode** | Perpetual: `oneway` (single direction) or `hedge` (both directions) |

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 node_modules/
 logs/
+keys/
 .vscode/
 tests.js
 config.*.jsonc
 config.jsonc
+config.dev.jsonc
 !config.default.jsonc
 .DS_Store
 .idea/
@@ -17,3 +19,5 @@ test_encode.py
 coverage/
 trade/settings/*
 !trade/settings/tradeParams_Default.js
+CLAUDE.md
+.ai-tasks/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD029": false,
+  "MD024": {"siblings_only": true}
+}


### PR DESCRIPTION
## Description

This PR adds OSS-specific documentation for AI agents under `.github/` and aligns it with ADAMANT organization-wide contribution rules.

### What changed

- added `.github/ai-agent-instructions.md`
- added `.github/exchange-connector-guide.md`
- documented the OSS branch scope instead of Premium-only assumptions
- defined a REST-first, spot-only baseline for exchange connectors
- added organization-wide guidance for English-only repository artifacts, issue prefixes, labels, and PR conventions
- added explicit JSDoc expectations for functions, parameters, and return values
- added markdownlint support for maintaining these docs cleanly

## Related issue

Closes #96

## How to test

1. Review `.github/ai-agent-instructions.md` and confirm it describes the OSS branch rather than Premium workflows
2. Review `.github/exchange-connector-guide.md` and confirm it treats REST spot connectors as the default baseline
3. Verify the governance sections mention English-only repository artifacts, issue prefixes, label policy, PR conventions, and shared ADAMANT links
4. Verify the JSDoc sections require documenting functions, parameters, and return values
5. Confirm markdown files stay lint-clean with the repository markdownlint configuration

## Risk

Low.

This change is documentation-only, with a small supporting markdownlint configuration update.

## Checklist

- [x] Documentation updated
- [x] Scope aligned with the OSS branch
- [x] Related issue linked
- [x] Verification steps included
