### PR TITLE
docs: fix broken README references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After installation, you control the bot directly via a secure ADAMANT Messenger 
 
 * Ubuntu 20+, centOS 8+ (we didn't test others)
 * NodeJS v18+
-* MongoDB ([installation instructions](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/))
+* MongoDB ([installation instructions](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/))
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Automated README maintenance for `Adamant-im/adamant-tradebot` focused on dead links and stale API references.

## Changed files
- `README.md`: 1 edit(s)

## Validation
- Reviewed README Markdown files only.
- Kept edits minimal and localized to broken references or outdated API endpoints.

Automated README maintenance pass focused on dead links and stale API references. If this saved you time, coffee on Base is always appreciated: 0x85a7d7eefac69d5f90615cf72a4dcc5657370e2c