### PR TITLE
Chore: Migrate npm publish workflow to OIDC

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,7 +24,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout release tag
+      - name: Checkout source
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
@@ -43,7 +43,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,14 +1,24 @@
 name: Publish npm package
 
-# Runs when a GitHub Release is published (not on every push).
-# The job is skipped unless the release tag points to a commit on master.
+# Publishes the package to npm with build provenance when a GitHub Release is
+# published. Authentication uses npm Trusted Publishing (OIDC) — no token is
+# stored in the repository.
+#
+# One-time setup on npmjs.com (package Settings -> Trusted Publishing):
+# - Publisher: GitHub Actions
+# - Organization: Adamant-im
+# - Repository: adamant-tradebot
+# - Workflow filename: publish-npm.yml
+# - Environment: (leave empty)
+
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -17,10 +27,11 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.ref }}
           fetch-depth: 0
 
       - name: Verify release tag is on master
+        if: github.event_name == 'release'
         run: |
           git fetch origin master
           git merge-base --is-ancestor HEAD origin/master
@@ -28,13 +39,24 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify package version matches the release tag
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "socket.io-parser": "^4.2.6"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Switch npm publishing in `.github/workflows/publish-npm.yml` from `NPM_TOKEN` to **Trusted Publishing (OIDC)**.

Trusted Publisher is already configured on npmjs.com for `Adamant-im/adamant-tradebot` and workflow file `publish-npm.yml`. This aligns the tradebot with `adamant-api` and `adamant-console` publish workflows.

## Related issue

Closes #119

## Changes

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step
- Node.js 24 + `npm install -g npm@latest` for OIDC-compatible npm CLI
- Add `workflow_dispatch` trigger for manual publish verification
- Add release tag ↔ `package.json` version guard on release events
- Add workflow header comments documenting Trusted Publisher setup
- Set `publishConfig.provenance: true` in `package.json`

## Breaking changes

No runtime or user-facing breaking changes. CI-only change.

## How to test

1. Merge to `dev`, then `master`
2. Optionally run **Publish npm package** via `workflow_dispatch` on `master` (dry run not available — use a patch release or test on next tag)
3. On next release (`v9.0.1` or later), confirm:
   - Workflow succeeds without `NPM_TOKEN`
   - npm shows publisher **GitHub Actions** with provenance badge
4. Revoke `NPM_TOKEN` secret after successful OIDC publish

## Notes for reviewers

- `id-token: write` was already present; this PR removes the token fallback path
- Docker publish workflow is unchanged
- v9.0.0 was published with token; OIDC applies from the next release onward

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [ ] Changes tested in all relevant environments (verify on next release)
